### PR TITLE
Feature/main map layout

### DIFF
--- a/App/LocationNote/LocationNote.xcodeproj/project.pbxproj
+++ b/App/LocationNote/LocationNote.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		BBF8F7EA290D5347003C06D1 /* MainRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF8F7E9290D5347003C06D1 /* MainRouter.swift */; };
 		BBF8F7EC290D539F003C06D1 /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF8F7EB290D539F003C06D1 /* RootViewController.swift */; };
 		BBF8F7F4290D5F4B003C06D1 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF8F7F3290D5F4B003C06D1 /* BaseViewController.swift */; };
+		BBF8F7FA290D610D003C06D1 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF8F7F9290D610D003C06D1 /* SearchBar.swift */; };
+		BBF8F7FC290D611A003C06D1 /* SearchBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = BBF8F7FB290D611A003C06D1 /* SearchBar.xib */; };
 		F47224C14C2B9A6E561CFF40 /* Pods_LocationNote.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B035DDBCBAC3CB750286DD0 /* Pods_LocationNote.framework */; };
 /* End PBXBuildFile section */
 
@@ -69,6 +71,8 @@
 		BBF8F7E9290D5347003C06D1 /* MainRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainRouter.swift; sourceTree = "<group>"; };
 		BBF8F7EB290D539F003C06D1 /* RootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewController.swift; sourceTree = "<group>"; };
 		BBF8F7F3290D5F4B003C06D1 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		BBF8F7F9290D610D003C06D1 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
+		BBF8F7FB290D611A003C06D1 /* SearchBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchBar.xib; sourceTree = "<group>"; };
 		C531066F39FABA4D8BC31FB1 /* Pods_LocationNoteTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LocationNoteTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC2B9D561C0B4B736AE4BC60 /* Pods-LocationNoteTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LocationNoteTests.release.xcconfig"; path = "Target Support Files/Pods-LocationNoteTests/Pods-LocationNoteTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -149,6 +153,7 @@
 		BBA94A5E2906C7B000E9B2F7 /* LocationNote */ = {
 			isa = PBXGroup;
 			children = (
+				BBF8F7F7290D60D8003C06D1 /* ViewParts */,
 				BBA94A942906C87B00E9B2F7 /* Screen */,
 				BBA94A932906C86700E9B2F7 /* Shared */,
 				BBA94A6B2906C7B200E9B2F7 /* Assets.xcassets */,
@@ -220,6 +225,23 @@
 				BBF8F7F3290D5F4B003C06D1 /* BaseViewController.swift */,
 			);
 			path = Base;
+			sourceTree = "<group>";
+		};
+		BBF8F7F7290D60D8003C06D1 /* ViewParts */ = {
+			isa = PBXGroup;
+			children = (
+				BBF8F7F8290D60EE003C06D1 /* SearchBar */,
+			);
+			path = ViewParts;
+			sourceTree = "<group>";
+		};
+		BBF8F7F8290D60EE003C06D1 /* SearchBar */ = {
+			isa = PBXGroup;
+			children = (
+				BBF8F7F9290D610D003C06D1 /* SearchBar.swift */,
+				BBF8F7FB290D611A003C06D1 /* SearchBar.xib */,
+			);
+			path = SearchBar;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -334,6 +356,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BBA94A6F2906C7B200E9B2F7 /* LaunchScreen.storyboard in Resources */,
+				BBF8F7FC290D611A003C06D1 /* SearchBar.xib in Resources */,
 				BBA94A6C2906C7B200E9B2F7 /* Assets.xcassets in Resources */,
 				BBA94A672906C7B000E9B2F7 /* Main.storyboard in Resources */,
 			);
@@ -507,6 +530,7 @@
 				BBB5346B290D1BA10007AE3E /* R.generated.swift in Sources */,
 				BBF8F7EC290D539F003C06D1 /* RootViewController.swift in Sources */,
 				BBA94A602906C7B000E9B2F7 /* AppDelegate.swift in Sources */,
+				BBF8F7FA290D610D003C06D1 /* SearchBar.swift in Sources */,
 				BBF8F7F4290D5F4B003C06D1 /* BaseViewController.swift in Sources */,
 				BBA94A622906C7B000E9B2F7 /* SceneDelegate.swift in Sources */,
 				BBF8F7EA290D5347003C06D1 /* MainRouter.swift in Sources */,

--- a/App/LocationNote/LocationNote.xcodeproj/project.pbxproj
+++ b/App/LocationNote/LocationNote.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		724DE64B51024D9ADB83AEA4 /* Pods_LocationNote_LocationNoteUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E3C5730336A5398F3D8DD23 /* Pods_LocationNote_LocationNoteUITests.framework */; };
 		A5236E51790FE1D406B07EB8 /* Pods_LocationNoteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C531066F39FABA4D8BC31FB1 /* Pods_LocationNoteTests.framework */; };
+		BB8F1CE7290D7D05005C97A2 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8F1CE6290D7D05005C97A2 /* ViewExtension.swift */; };
 		BBA94A602906C7B000E9B2F7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA94A5F2906C7B000E9B2F7 /* AppDelegate.swift */; };
 		BBA94A622906C7B000E9B2F7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA94A612906C7B000E9B2F7 /* SceneDelegate.swift */; };
 		BBA94A642906C7B000E9B2F7 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA94A632906C7B000E9B2F7 /* MainViewController.swift */; };
@@ -53,6 +54,7 @@
 		5E8E40245F3326C60EFEF4C6 /* Pods-LocationNote.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LocationNote.debug.xcconfig"; path = "Target Support Files/Pods-LocationNote/Pods-LocationNote.debug.xcconfig"; sourceTree = "<group>"; };
 		6E3C5730336A5398F3D8DD23 /* Pods_LocationNote_LocationNoteUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LocationNote_LocationNoteUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B53D729CD0EF0D2CD3ADA11 /* Pods-LocationNote.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LocationNote.release.xcconfig"; path = "Target Support Files/Pods-LocationNote/Pods-LocationNote.release.xcconfig"; sourceTree = "<group>"; };
+		BB8F1CE6290D7D05005C97A2 /* ViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
 		BBA94A5C2906C7B000E9B2F7 /* LocationNote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LocationNote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBA94A5F2906C7B000E9B2F7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BBA94A612906C7B000E9B2F7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -128,6 +130,14 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		BB8F1CE5290D7CF1005C97A2 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				BB8F1CE6290D7D05005C97A2 /* ViewExtension.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		BBA94A532906C7B000E9B2F7 = {
 			isa = PBXGroup;
 			children = (
@@ -155,6 +165,7 @@
 			children = (
 				BBF8F7F7290D60D8003C06D1 /* ViewParts */,
 				BBA94A942906C87B00E9B2F7 /* Screen */,
+				BB8F1CE5290D7CF1005C97A2 /* Extension */,
 				BBA94A932906C86700E9B2F7 /* Shared */,
 				BBA94A6B2906C7B200E9B2F7 /* Assets.xcassets */,
 				BBA94A6D2906C7B200E9B2F7 /* LaunchScreen.storyboard */,
@@ -529,6 +540,7 @@
 				BBA94A642906C7B000E9B2F7 /* MainViewController.swift in Sources */,
 				BBB5346B290D1BA10007AE3E /* R.generated.swift in Sources */,
 				BBF8F7EC290D539F003C06D1 /* RootViewController.swift in Sources */,
+				BB8F1CE7290D7D05005C97A2 /* ViewExtension.swift in Sources */,
 				BBA94A602906C7B000E9B2F7 /* AppDelegate.swift in Sources */,
 				BBF8F7FA290D610D003C06D1 /* SearchBar.swift in Sources */,
 				BBF8F7F4290D5F4B003C06D1 /* BaseViewController.swift in Sources */,

--- a/App/LocationNote/LocationNote/Extension/ViewExtension.swift
+++ b/App/LocationNote/LocationNote/Extension/ViewExtension.swift
@@ -1,0 +1,22 @@
+//
+//  ViewExtension.swift
+//  LocationNote
+//
+//  Created by k17124kk on 2022/10/30.
+//
+
+import Foundation
+import UIKit
+
+extension UIView {
+    func addShadow() {
+        // 影の方向（width=右方向、height=下方向、CGSize.zero=方向指定なし）
+        layer.shadowOffset = CGSize(width: 0.0, height: 2.0)
+        // 影の色
+        layer.shadowColor = UIColor.black.cgColor
+        // 影の濃さ
+        layer.shadowOpacity = 0.5
+        // 影をぼかし
+        layer.shadowRadius = 4
+    }
+}

--- a/App/LocationNote/LocationNote/Screen/Main/Base.lproj/Main.storyboard
+++ b/App/LocationNote/LocationNote/Screen/Main/Base.lproj/Main.storyboard
@@ -4,9 +4,10 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
+        <capability name="Map view configurations" minToolsVersion="14.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,29 +19,70 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Main" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BNn-Ph-DcS">
-                                <rect key="frame" x="174" y="412" width="37" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" name="AccentColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n5R-c8-iYt">
+                                <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                                <standardMapConfiguration key="preferredConfiguration"/>
+                            </mapView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BVP-Hn-ftq" customClass="SearchBar" customModule="LocationNote" customModuleProvider="target">
+                                <rect key="frame" x="24" y="47" width="342" height="44"/>
+                                <color key="backgroundColor" name="white1"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="3sX-mw-5Te"/>
+                                </constraints>
+                            </view>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OLw-NZ-Eik">
+                                <rect key="frame" x="311" y="707" width="55" height="55"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="OLw-NZ-Eik" secondAttribute="height" multiplier="1:1" id="HFu-bu-cjj"/>
+                                    <constraint firstAttribute="height" constant="55" id="v9K-OU-JCt"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled">
+                                    <imageReference key="image" image="plus.circle.fill" catalog="system" symbolScale="large"/>
+                                </buttonConfiguration>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rbo-Ct-al8">
+                                <rect key="frame" x="311" y="616" width="55" height="55"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="rbo-Ct-al8" secondAttribute="height" multiplier="1:1" id="JfY-5Z-ncR"/>
+                                    <constraint firstAttribute="height" constant="55" id="slW-kV-ENZ"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" image="paperplane.fill" catalog="system"/>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" name="white1"/>
+                        <constraints>
+                            <constraint firstItem="BVP-Hn-ftq" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="3gl-hA-V91"/>
+                            <constraint firstItem="n5R-c8-iYt" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="68K-3C-8q2"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="rbo-Ct-al8" secondAttribute="trailing" constant="24" id="865-hA-OGi"/>
+                            <constraint firstItem="n5R-c8-iYt" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="AMH-70-Egt"/>
+                            <constraint firstItem="rbo-Ct-al8" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6Tk-OE-BBY" secondAttribute="leading" symbolic="YES" id="CNa-zm-uzH"/>
+                            <constraint firstItem="OLw-NZ-Eik" firstAttribute="top" secondItem="rbo-Ct-al8" secondAttribute="bottom" constant="36" id="EGW-le-66s"/>
+                            <constraint firstItem="OLw-NZ-Eik" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6Tk-OE-BBY" secondAttribute="leading" symbolic="YES" id="Kb9-3c-Bvz"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="OLw-NZ-Eik" secondAttribute="bottom" constant="48" id="Ouu-48-Ue3"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="OLw-NZ-Eik" secondAttribute="trailing" constant="24" id="aGb-EH-Iri"/>
+                            <constraint firstAttribute="bottom" secondItem="n5R-c8-iYt" secondAttribute="bottom" id="ejy-g3-pLq"/>
+                            <constraint firstAttribute="trailing" secondItem="BVP-Hn-ftq" secondAttribute="trailing" constant="24" id="phv-2q-6sa"/>
+                            <constraint firstAttribute="trailing" secondItem="n5R-c8-iYt" secondAttribute="trailing" id="tkI-lc-Ks1"/>
+                            <constraint firstItem="BVP-Hn-ftq" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="24" id="w9v-sM-ASs"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="searchBar" destination="BVP-Hn-ftq" id="3nd-UK-SGT"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="58" y="-2"/>
+            <point key="canvasLocation" x="56.92307692307692" y="-2.1327014218009479"/>
         </scene>
     </scenes>
     <resources>
-        <namedColor name="AccentColor">
-            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <image name="paperplane.fill" catalog="system" width="128" height="119"/>
+        <image name="plus.circle.fill" catalog="system" width="128" height="123"/>
+        <namedColor name="white1">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/App/LocationNote/LocationNote/Screen/Main/Base.lproj/Main.storyboard
+++ b/App/LocationNote/LocationNote/Screen/Main/Base.lproj/Main.storyboard
@@ -37,9 +37,12 @@
                                     <constraint firstAttribute="height" constant="55" id="v9K-OU-JCt"/>
                                 </constraints>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled">
-                                    <imageReference key="image" image="plus.circle.fill" catalog="system" symbolScale="large"/>
+                                <buttonConfiguration key="configuration" style="filled" cornerStyle="capsule">
+                                    <imageReference key="image" image="plus" catalog="system" symbolScale="large"/>
                                 </buttonConfiguration>
+                                <connections>
+                                    <action selector="onLocateButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="SZQ-mS-5gt"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rbo-Ct-al8">
                                 <rect key="frame" x="311" y="616" width="55" height="55"/>
@@ -48,7 +51,10 @@
                                     <constraint firstAttribute="height" constant="55" id="slW-kV-ENZ"/>
                                 </constraints>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" image="paperplane.fill" catalog="system"/>
+                                <buttonConfiguration key="configuration" style="filled" image="paperplane.fill" catalog="system" cornerStyle="capsule"/>
+                                <connections>
+                                    <action selector="onAddButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="XR0-Zs-qNx"/>
+                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -70,6 +76,8 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="addButton" destination="OLw-NZ-Eik" id="0E1-D0-JWW"/>
+                        <outlet property="locateButton" destination="rbo-Ct-al8" id="BkW-Q5-3TD"/>
                         <outlet property="searchBar" destination="BVP-Hn-ftq" id="3nd-UK-SGT"/>
                     </connections>
                 </viewController>
@@ -80,7 +88,7 @@
     </scenes>
     <resources>
         <image name="paperplane.fill" catalog="system" width="128" height="119"/>
-        <image name="plus.circle.fill" catalog="system" width="128" height="123"/>
+        <image name="plus" catalog="system" width="128" height="113"/>
         <namedColor name="white1">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -9,11 +9,13 @@ import UIKit
 
 class MainViewController: BaseViewController {
 
+    @IBOutlet weak var searchBar: SearchBar!
+
     static func initFromStoryboard() -> UIViewController {
         let storyboard = UIStoryboard(name: R.storyboard.main.name, bundle: nil)
         let viewController = storyboard.instantiateInitialViewController() as! MainViewController
 
-        return UINavigationController(rootViewController: viewController)
+        return viewController
     }
 
     override func viewDidLoad() {

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -23,6 +23,8 @@ class MainViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        locateButton.addShadow()
+        addButton.addShadow()
     }
 
     @IBAction func onLocateButtonTapped(_ sender: Any) {

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 class MainViewController: BaseViewController {
 
     @IBOutlet weak var searchBar: SearchBar!
+    @IBOutlet weak var locateButton: UIButton!
+    @IBOutlet weak var addButton: UIButton!
 
     static func initFromStoryboard() -> UIViewController {
         let storyboard = UIStoryboard(name: R.storyboard.main.name, bundle: nil)
@@ -20,5 +22,12 @@ class MainViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+    }
+
+    @IBAction func onLocateButtonTapped(_ sender: Any) {
+    }
+
+    @IBAction func onAddButtonTapped(_ sender: Any) {
     }
 }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -9,11 +9,11 @@ import UIKit
 
 class MainViewController: BaseViewController {
 
-    static func initFromStoryboard() -> MainViewController {
+    static func initFromStoryboard() -> UIViewController {
         let storyboard = UIStoryboard(name: R.storyboard.main.name, bundle: nil)
         let viewController = storyboard.instantiateInitialViewController() as! MainViewController
 
-        return viewController
+        return UINavigationController(rootViewController: viewController)
     }
 
     override func viewDidLoad() {

--- a/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
+++ b/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
@@ -9,30 +9,38 @@ import UIKit
 
 class SearchBar: UIView {
 
-    @IBOutlet weak var stackView: UIStackView!
-    @IBOutlet weak var textField: UITextField!
-    @IBOutlet weak var clearButton: UIButton!
+    @IBOutlet private var stackView: UIStackView!
+    @IBOutlet private var textField: UITextField!
+    @IBOutlet private var clearButton: UIButton!
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setUpView()
+        loadView()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        setUpView()
+        loadView()
     }
 
 }
 
 extension SearchBar {
-    func setUpView() {
+    func loadView() {
         guard let view = R.nib.searchBar(owner: self) else {
             fatalError("error")
         }
-
         view.frame = self.bounds
         addSubview(view)
+
+        setUpView()
+    }
+
+    func setUpView() {
+        stackView.layer.borderWidth = 1.0
+        stackView.layer.borderColor = R.color.black2()?.cgColor
+        stackView.layer.cornerRadius = 14
+
     }
 
 }

--- a/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
+++ b/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
@@ -13,7 +13,6 @@ protocol SearchBarDelegate: AnyObject {
 
 class SearchBar: UIView {
 
-    @IBOutlet private var stackView: UIStackView!
     @IBOutlet private var textField: UITextField!
     @IBOutlet private var clearButton: UIButton!
 
@@ -47,21 +46,21 @@ extension SearchBar {
     }
 
     func setUpView() {
-        stackView.layer.borderWidth = 1.0
-        stackView.layer.borderColor = R.color.black2()?.cgColor
-        stackView.layer.cornerRadius = 14
+        layer.borderWidth = 1.0
+        layer.borderColor = R.color.black2()?.cgColor
+        layer.cornerRadius = 16
 
         textField.delegate = self
     }
 
     func setDefaultLayout() {
-        stackView.layer.borderWidth = 1.0
-        stackView.layer.borderColor = R.color.black2()?.cgColor
+        layer.borderWidth = 1.0
+        layer.borderColor = R.color.black2()?.cgColor
     }
 
     func setEdditingLayout() {
-        stackView.layer.borderWidth = 3.0
-        stackView.layer.borderColor = R.color.blue1()?.cgColor
+        layer.borderWidth = 3.0
+        layer.borderColor = R.color.blue1()?.cgColor
     }
 }
 

--- a/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
+++ b/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
@@ -1,0 +1,38 @@
+//
+//  SearchBar.swift
+//  LocationNote
+//
+//  Created by k17124kk on 2022/10/29.
+//
+
+import UIKit
+
+class SearchBar: UIView {
+
+    @IBOutlet weak var stackView: UIStackView!
+    @IBOutlet weak var textField: UITextField!
+    @IBOutlet weak var clearButton: UIButton!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUpView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setUpView()
+    }
+
+}
+
+extension SearchBar {
+    func setUpView() {
+        guard let view = R.nib.searchBar(owner: self) else {
+            fatalError("error")
+        }
+
+        view.frame = self.bounds
+        addSubview(view)
+    }
+
+}

--- a/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
+++ b/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
@@ -7,11 +7,17 @@
 
 import UIKit
 
+protocol SearchBarDelegate: AnyObject {
+    func onSearchTextFieldChanged(searchText: String)
+}
+
 class SearchBar: UIView {
 
     @IBOutlet private var stackView: UIStackView!
     @IBOutlet private var textField: UITextField!
     @IBOutlet private var clearButton: UIButton!
+
+    var delegate: SearchBarDelegate?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -71,5 +77,7 @@ extension SearchBar: UITextFieldDelegate {
 
     func textFieldDidChangeSelection(_ textField: UITextField) {
         clearButton.isHidden = textField.text?.isEmpty ?? true
+
+        delegate?.onSearchTextFieldChanged(searchText: textField.text ?? "")
     }
 }

--- a/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
+++ b/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
@@ -42,6 +42,8 @@ extension SearchBar {
         view.frame = self.bounds
         addSubview(view)
 
+        addShadow()
+
         setUpView()
     }
 

--- a/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
+++ b/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.swift
@@ -23,6 +23,10 @@ class SearchBar: UIView {
         loadView()
     }
 
+    @IBAction func onClearButtonTapped(_ sender: Any) {
+        textField.text = ""
+    }
+
 }
 
 extension SearchBar {
@@ -41,6 +45,31 @@ extension SearchBar {
         stackView.layer.borderColor = R.color.black2()?.cgColor
         stackView.layer.cornerRadius = 14
 
+        textField.delegate = self
     }
 
+    func setDefaultLayout() {
+        stackView.layer.borderWidth = 1.0
+        stackView.layer.borderColor = R.color.black2()?.cgColor
+    }
+
+    func setEdditingLayout() {
+        stackView.layer.borderWidth = 3.0
+        stackView.layer.borderColor = R.color.blue1()?.cgColor
+    }
+}
+
+extension SearchBar: UITextFieldDelegate {
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        setEdditingLayout()
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        setDefaultLayout()
+    }
+
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        clearButton.isHidden = textField.text?.isEmpty ?? true
+    }
 }

--- a/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.xib
+++ b/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.xib
@@ -55,10 +55,11 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="s7d-M6-U6P" userLabel="textField">
-                            <rect key="frame" x="44" y="0.0" width="74" height="39"/>
+                            <rect key="frame" x="44" y="0.0" width="62" height="39"/>
                             <subviews>
                                 <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="タイトル/コメントで検索" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6UH-8W-1pY">
-                                    <rect key="frame" x="0.0" y="0.0" width="74" height="39"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="62" height="39"/>
+                                    <color key="tintColor" name="Blue1"/>
                                     <color key="textColor" name="black1"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                     <textInputTraits key="textInputTraits"/>
@@ -73,14 +74,14 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MoY-W6-ZWU" userLabel="margin">
-                            <rect key="frame" x="118" y="0.0" width="12" height="39"/>
+                            <rect key="frame" x="106" y="0.0" width="12" height="39"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="12" id="SDx-ny-leR"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fgR-iH-IPB" userLabel="deleteButton">
-                            <rect key="frame" x="130" y="0.0" width="20" height="39"/>
+                            <rect key="frame" x="118" y="0.0" width="20" height="39"/>
                             <subviews>
                                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rn9-JX-hBd">
                                     <rect key="frame" x="0.0" y="9.6666666666666679" width="20" height="20"/>
@@ -91,6 +92,9 @@
                                     <color key="tintColor" name="black2"/>
                                     <state key="normal" title="Button"/>
                                     <buttonConfiguration key="configuration" style="plain" image="clear.fill" catalog="system"/>
+                                    <connections>
+                                        <action selector="onClearButtonTapped:" destination="-1" eventType="touchUpInside" id="ePk-YL-Sac"/>
+                                    </connections>
                                 </button>
                             </subviews>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -101,10 +105,10 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yab-WZ-vxr" userLabel="margin">
-                            <rect key="frame" x="150" y="0.0" width="12" height="39"/>
+                            <rect key="frame" x="138" y="0.0" width="24" height="39"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="12" id="n55-Yi-025"/>
+                                <constraint firstAttribute="width" constant="24" id="n55-Yi-025"/>
                             </constraints>
                         </view>
                     </subviews>
@@ -129,6 +133,9 @@
     <resources>
         <image name="clear.fill" catalog="system" width="128" height="114"/>
         <image name="magnifyingglass" catalog="system" width="128" height="117"/>
+        <namedColor name="Blue1">
+            <color red="0.33725490196078434" green="0.75686274509803919" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="black1">
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.xib
+++ b/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.xib
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SearchBar" customModule="LocationNote" customModuleProvider="target">
+            <connections>
+                <outlet property="clearButton" destination="rn9-JX-hBd" id="e6e-A2-CuA"/>
+                <outlet property="stackView" destination="O6C-2N-oHp" id="Aga-Fr-J5e"/>
+                <outlet property="textField" destination="6UH-8W-1pY" id="1Tf-yl-mVR"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="206" height="63"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O6C-2N-oHp">
+                    <rect key="frame" x="24" y="8" width="158" height="47"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KLr-NG-ity" userLabel="margin">
+                            <rect key="frame" x="0.0" y="0.0" width="8" height="47"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="8" id="4kF-Y5-ihm"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XW4-gb-350" userLabel="searchIcon">
+                            <rect key="frame" x="8" y="0.0" width="20" height="47"/>
+                            <subviews>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="magnifyingglass" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="mEN-wf-DGm">
+                                    <rect key="frame" x="0.0" y="14.33333333333333" width="20.333333333333332" height="18.666666666666664"/>
+                                    <color key="tintColor" name="black2"/>
+                                </imageView>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="20" id="2nW-l2-Vmo"/>
+                                <constraint firstItem="mEN-wf-DGm" firstAttribute="centerX" secondItem="XW4-gb-350" secondAttribute="centerX" id="6St-tR-gPk"/>
+                                <constraint firstItem="mEN-wf-DGm" firstAttribute="centerY" secondItem="XW4-gb-350" secondAttribute="centerY" id="98S-4r-Qwc"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5iB-Xa-QIR" userLabel="margin">
+                            <rect key="frame" x="28" y="0.0" width="12" height="47"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="12" id="Wif-Dh-oTW"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="s7d-M6-U6P" userLabel="textField">
+                            <rect key="frame" x="40" y="0.0" width="78" height="47"/>
+                            <subviews>
+                                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="aaaaaaaa" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6UH-8W-1pY">
+                                    <rect key="frame" x="0.0" y="0.0" width="78" height="47"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textInputTraits key="textInputTraits"/>
+                                </textField>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="bottom" secondItem="6UH-8W-1pY" secondAttribute="bottom" id="5f3-Uu-R1z"/>
+                                <constraint firstItem="6UH-8W-1pY" firstAttribute="leading" secondItem="s7d-M6-U6P" secondAttribute="leading" id="7OI-Ch-fjc"/>
+                                <constraint firstItem="6UH-8W-1pY" firstAttribute="top" secondItem="s7d-M6-U6P" secondAttribute="top" id="W0S-eY-Teo"/>
+                                <constraint firstAttribute="trailing" secondItem="6UH-8W-1pY" secondAttribute="trailing" id="duP-ov-cRu"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MoY-W6-ZWU" userLabel="margin">
+                            <rect key="frame" x="118" y="0.0" width="12" height="47"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="12" id="SDx-ny-leR"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fgR-iH-IPB" userLabel="deleteButton">
+                            <rect key="frame" x="130" y="0.0" width="20" height="47"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rn9-JX-hBd">
+                                    <rect key="frame" x="0.0" y="13.666666666666668" width="20" height="20.000000000000004"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="20" id="4Uz-K6-Zec"/>
+                                        <constraint firstAttribute="width" constant="20" id="hch-Jm-ebg"/>
+                                    </constraints>
+                                    <color key="tintColor" name="black2"/>
+                                    <state key="normal" title="Button"/>
+                                    <buttonConfiguration key="configuration" style="plain" image="clear.fill" catalog="system"/>
+                                </button>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstItem="rn9-JX-hBd" firstAttribute="centerY" secondItem="fgR-iH-IPB" secondAttribute="centerY" id="MGN-xs-c4B"/>
+                                <constraint firstItem="rn9-JX-hBd" firstAttribute="centerX" secondItem="fgR-iH-IPB" secondAttribute="centerX" id="gnR-Rb-JY9"/>
+                                <constraint firstAttribute="width" constant="20" id="tty-RA-n9V"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yab-WZ-vxr" userLabel="margin">
+                            <rect key="frame" x="150" y="0.0" width="8" height="47"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="8" id="n55-Yi-025"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="XW4-gb-350" secondAttribute="bottom" id="kSN-Ye-A1k"/>
+                        <constraint firstItem="XW4-gb-350" firstAttribute="top" secondItem="O6C-2N-oHp" secondAttribute="top" id="mnN-sa-Qae"/>
+                    </constraints>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="O6C-2N-oHp" secondAttribute="trailing" constant="24" id="Hl0-bu-lX2"/>
+                <constraint firstItem="O6C-2N-oHp" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="SQ0-NB-Mkf"/>
+                <constraint firstItem="O6C-2N-oHp" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="24" id="xjR-WW-wlK"/>
+                <constraint firstAttribute="bottom" secondItem="O6C-2N-oHp" secondAttribute="bottom" constant="8" id="xsl-eD-yNv"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="-446.15384615384613" y="289.69194312796208"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="clear.fill" catalog="system" width="128" height="114"/>
+        <image name="magnifyingglass" catalog="system" width="128" height="117"/>
+        <namedColor name="black2">
+            <color red="0.36862745098039218" green="0.36862745098039218" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.xib
+++ b/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.xib
@@ -19,24 +19,24 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="206" height="63"/>
+            <rect key="frame" x="0.0" y="0.0" width="210" height="63"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O6C-2N-oHp">
-                    <rect key="frame" x="24" y="8" width="158" height="47"/>
+                    <rect key="frame" x="24" y="12" width="162" height="39"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KLr-NG-ity" userLabel="margin">
-                            <rect key="frame" x="0.0" y="0.0" width="8" height="47"/>
+                            <rect key="frame" x="0.0" y="0.0" width="12" height="39"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="8" id="4kF-Y5-ihm"/>
+                                <constraint firstAttribute="width" constant="12" id="4kF-Y5-ihm"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XW4-gb-350" userLabel="searchIcon">
-                            <rect key="frame" x="8" y="0.0" width="20" height="47"/>
+                            <rect key="frame" x="12" y="0.0" width="20" height="39"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="magnifyingglass" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="mEN-wf-DGm">
-                                    <rect key="frame" x="0.0" y="14.33333333333333" width="20.333333333333332" height="18.666666666666664"/>
+                                    <rect key="frame" x="0.0" y="10.33333333333333" width="20.333333333333332" height="18.666666666666664"/>
                                     <color key="tintColor" name="black2"/>
                                 </imageView>
                             </subviews>
@@ -48,18 +48,19 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5iB-Xa-QIR" userLabel="margin">
-                            <rect key="frame" x="28" y="0.0" width="12" height="47"/>
+                            <rect key="frame" x="32" y="0.0" width="12" height="39"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="12" id="Wif-Dh-oTW"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="s7d-M6-U6P" userLabel="textField">
-                            <rect key="frame" x="40" y="0.0" width="78" height="47"/>
+                            <rect key="frame" x="44" y="0.0" width="74" height="39"/>
                             <subviews>
-                                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="aaaaaaaa" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6UH-8W-1pY">
-                                    <rect key="frame" x="0.0" y="0.0" width="78" height="47"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="タイトル/コメントで検索" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6UH-8W-1pY">
+                                    <rect key="frame" x="0.0" y="0.0" width="74" height="39"/>
+                                    <color key="textColor" name="black1"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                     <textInputTraits key="textInputTraits"/>
                                 </textField>
                             </subviews>
@@ -72,17 +73,17 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MoY-W6-ZWU" userLabel="margin">
-                            <rect key="frame" x="118" y="0.0" width="12" height="47"/>
+                            <rect key="frame" x="118" y="0.0" width="12" height="39"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="12" id="SDx-ny-leR"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fgR-iH-IPB" userLabel="deleteButton">
-                            <rect key="frame" x="130" y="0.0" width="20" height="47"/>
+                            <rect key="frame" x="130" y="0.0" width="20" height="39"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rn9-JX-hBd">
-                                    <rect key="frame" x="0.0" y="13.666666666666668" width="20" height="20.000000000000004"/>
+                                <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rn9-JX-hBd">
+                                    <rect key="frame" x="0.0" y="9.6666666666666679" width="20" height="20"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="20" id="4Uz-K6-Zec"/>
                                         <constraint firstAttribute="width" constant="20" id="hch-Jm-ebg"/>
@@ -100,10 +101,10 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yab-WZ-vxr" userLabel="margin">
-                            <rect key="frame" x="150" y="0.0" width="8" height="47"/>
+                            <rect key="frame" x="150" y="0.0" width="12" height="39"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="8" id="n55-Yi-025"/>
+                                <constraint firstAttribute="width" constant="12" id="n55-Yi-025"/>
                             </constraints>
                         </view>
                     </subviews>
@@ -117,17 +118,20 @@
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="O6C-2N-oHp" secondAttribute="trailing" constant="24" id="Hl0-bu-lX2"/>
-                <constraint firstItem="O6C-2N-oHp" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="SQ0-NB-Mkf"/>
+                <constraint firstItem="O6C-2N-oHp" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="12" id="SQ0-NB-Mkf"/>
                 <constraint firstItem="O6C-2N-oHp" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="24" id="xjR-WW-wlK"/>
-                <constraint firstAttribute="bottom" secondItem="O6C-2N-oHp" secondAttribute="bottom" constant="8" id="xsl-eD-yNv"/>
+                <constraint firstAttribute="bottom" secondItem="O6C-2N-oHp" secondAttribute="bottom" constant="12" id="xsl-eD-yNv"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-446.15384615384613" y="289.69194312796208"/>
+            <point key="canvasLocation" x="-381.53846153846155" y="289.69194312796208"/>
         </view>
     </objects>
     <resources>
         <image name="clear.fill" catalog="system" width="128" height="114"/>
         <image name="magnifyingglass" catalog="system" width="128" height="117"/>
+        <namedColor name="black1">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="black2">
             <color red="0.36862745098039218" green="0.36862745098039218" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.xib
+++ b/App/LocationNote/LocationNote/ViewParts/SearchBar/SearchBar.xib
@@ -6,14 +6,12 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SearchBar" customModule="LocationNote" customModuleProvider="target">
             <connections>
                 <outlet property="clearButton" destination="rn9-JX-hBd" id="e6e-A2-CuA"/>
-                <outlet property="stackView" destination="O6C-2N-oHp" id="Aga-Fr-J5e"/>
                 <outlet property="textField" destination="6UH-8W-1pY" id="1Tf-yl-mVR"/>
             </connections>
         </placeholder>
@@ -23,24 +21,22 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O6C-2N-oHp">
-                    <rect key="frame" x="24" y="12" width="162" height="39"/>
+                    <rect key="frame" x="0.0" y="0.0" width="210" height="63"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KLr-NG-ity" userLabel="margin">
-                            <rect key="frame" x="0.0" y="0.0" width="12" height="39"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <rect key="frame" x="0.0" y="0.0" width="12" height="63"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="12" id="4kF-Y5-ihm"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XW4-gb-350" userLabel="searchIcon">
-                            <rect key="frame" x="12" y="0.0" width="20" height="39"/>
+                            <rect key="frame" x="12" y="0.0" width="20" height="63"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="magnifyingglass" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="mEN-wf-DGm">
-                                    <rect key="frame" x="0.0" y="10.33333333333333" width="20.333333333333332" height="18.666666666666664"/>
+                                    <rect key="frame" x="0.0" y="22.333333333333329" width="20.333333333333332" height="18.666666666666671"/>
                                     <color key="tintColor" name="black2"/>
                                 </imageView>
                             </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="20" id="2nW-l2-Vmo"/>
                                 <constraint firstItem="mEN-wf-DGm" firstAttribute="centerX" secondItem="XW4-gb-350" secondAttribute="centerX" id="6St-tR-gPk"/>
@@ -48,24 +44,22 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5iB-Xa-QIR" userLabel="margin">
-                            <rect key="frame" x="32" y="0.0" width="12" height="39"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <rect key="frame" x="32" y="0.0" width="12" height="63"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="12" id="Wif-Dh-oTW"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="s7d-M6-U6P" userLabel="textField">
-                            <rect key="frame" x="44" y="0.0" width="62" height="39"/>
+                            <rect key="frame" x="44" y="0.0" width="110" height="63"/>
                             <subviews>
                                 <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="タイトル/コメントで検索" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6UH-8W-1pY">
-                                    <rect key="frame" x="0.0" y="0.0" width="62" height="39"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="110" height="63"/>
                                     <color key="tintColor" name="Blue1"/>
                                     <color key="textColor" name="black1"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                     <textInputTraits key="textInputTraits"/>
                                 </textField>
                             </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="bottom" secondItem="6UH-8W-1pY" secondAttribute="bottom" id="5f3-Uu-R1z"/>
                                 <constraint firstItem="6UH-8W-1pY" firstAttribute="leading" secondItem="s7d-M6-U6P" secondAttribute="leading" id="7OI-Ch-fjc"/>
@@ -74,17 +68,16 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MoY-W6-ZWU" userLabel="margin">
-                            <rect key="frame" x="106" y="0.0" width="12" height="39"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <rect key="frame" x="154" y="0.0" width="12" height="63"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="12" id="SDx-ny-leR"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fgR-iH-IPB" userLabel="deleteButton">
-                            <rect key="frame" x="118" y="0.0" width="20" height="39"/>
+                            <rect key="frame" x="166" y="0.0" width="20" height="63"/>
                             <subviews>
                                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rn9-JX-hBd">
-                                    <rect key="frame" x="0.0" y="9.6666666666666679" width="20" height="20"/>
+                                    <rect key="frame" x="0.0" y="21.666666666666668" width="20" height="20.000000000000004"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="20" id="4Uz-K6-Zec"/>
                                         <constraint firstAttribute="width" constant="20" id="hch-Jm-ebg"/>
@@ -97,7 +90,6 @@
                                     </connections>
                                 </button>
                             </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstItem="rn9-JX-hBd" firstAttribute="centerY" secondItem="fgR-iH-IPB" secondAttribute="centerY" id="MGN-xs-c4B"/>
                                 <constraint firstItem="rn9-JX-hBd" firstAttribute="centerX" secondItem="fgR-iH-IPB" secondAttribute="centerX" id="gnR-Rb-JY9"/>
@@ -105,8 +97,7 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yab-WZ-vxr" userLabel="margin">
-                            <rect key="frame" x="138" y="0.0" width="24" height="39"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <rect key="frame" x="186" y="0.0" width="24" height="63"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="24" id="n55-Yi-025"/>
                             </constraints>
@@ -119,12 +110,11 @@
                 </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="O6C-2N-oHp" secondAttribute="trailing" constant="24" id="Hl0-bu-lX2"/>
-                <constraint firstItem="O6C-2N-oHp" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="12" id="SQ0-NB-Mkf"/>
-                <constraint firstItem="O6C-2N-oHp" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="24" id="xjR-WW-wlK"/>
-                <constraint firstAttribute="bottom" secondItem="O6C-2N-oHp" secondAttribute="bottom" constant="12" id="xsl-eD-yNv"/>
+                <constraint firstItem="O6C-2N-oHp" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="SQ0-NB-Mkf"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="O6C-2N-oHp" secondAttribute="trailing" id="eGH-WC-2AR"/>
+                <constraint firstItem="O6C-2N-oHp" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="xjR-WW-wlK"/>
+                <constraint firstAttribute="bottom" secondItem="O6C-2N-oHp" secondAttribute="bottom" id="xsl-eD-yNv"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="-381.53846153846155" y="289.69194312796208"/>
@@ -142,8 +132,5 @@
         <namedColor name="black2">
             <color red="0.36862745098039218" green="0.36862745098039218" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/App/LocationNote/R.generated.swift
+++ b/App/LocationNote/R.generated.swift
@@ -398,6 +398,7 @@ struct _R: Rswift.Validatable {
         if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "clear.fill") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'clear.fill' is used in nib 'SearchBar', but couldn't be loaded.") } }
         if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "magnifyingglass") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'magnifyingglass' is used in nib 'SearchBar', but couldn't be loaded.") } }
         if #available(iOS 11.0, tvOS 11.0, *) {
+          if UIKit.UIColor(named: "black1", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'black1' is used in nib 'SearchBar', but couldn't be loaded.") }
           if UIKit.UIColor(named: "black2", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'black2' is used in nib 'SearchBar', but couldn't be loaded.") }
         }
       }
@@ -447,7 +448,6 @@ struct _R: Rswift.Validatable {
       static func validate() throws {
         if #available(iOS 11.0, tvOS 11.0, *) {
           if UIKit.UIColor(named: "AccentColor", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'AccentColor' is used in storyboard 'Main', but couldn't be loaded.") }
-          if UIKit.UIColor(named: "black2", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'black2' is used in storyboard 'Main', but couldn't be loaded.") }
         }
       }
 

--- a/App/LocationNote/R.generated.swift
+++ b/App/LocationNote/R.generated.swift
@@ -448,7 +448,7 @@ struct _R: Rswift.Validatable {
 
       static func validate() throws {
         if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "paperplane.fill") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'paperplane.fill' is used in storyboard 'Main', but couldn't be loaded.") } }
-        if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "plus.circle.fill") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'plus.circle.fill' is used in storyboard 'Main', but couldn't be loaded.") } }
+        if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "plus") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'plus' is used in storyboard 'Main', but couldn't be loaded.") } }
         if #available(iOS 11.0, tvOS 11.0, *) {
           if UIKit.UIColor(named: "white1", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'white1' is used in storyboard 'Main', but couldn't be loaded.") }
         }

--- a/App/LocationNote/R.generated.swift
+++ b/App/LocationNote/R.generated.swift
@@ -337,6 +337,26 @@ struct R: Rswift.Validatable {
     fileprivate init() {}
   }
 
+  /// This `R.nib` struct is generated, and contains static references to 1 nibs.
+  struct nib {
+    /// Nib `SearchBar`.
+    static let searchBar = _R.nib._SearchBar()
+
+    #if os(iOS) || os(tvOS)
+    /// `UINib(name: "SearchBar", in: bundle)`
+    @available(*, deprecated, message: "Use UINib(resource: R.nib.searchBar) instead")
+    static func searchBar(_: Void = ()) -> UIKit.UINib {
+      return UIKit.UINib(resource: R.nib.searchBar)
+    }
+    #endif
+
+    static func searchBar(owner ownerOrNil: AnyObject?, options optionsOrNil: [UINib.OptionsKey : Any]? = nil) -> UIKit.UIView? {
+      return R.nib.searchBar.instantiate(withOwner: ownerOrNil, options: optionsOrNil)[0] as? UIKit.UIView
+    }
+
+    fileprivate init() {}
+  }
+
   fileprivate struct intern: Rswift.Validatable {
     fileprivate static func validate() throws {
       try _R.validate()
@@ -353,9 +373,41 @@ struct R: Rswift.Validatable {
 struct _R: Rswift.Validatable {
   static func validate() throws {
     #if os(iOS) || os(tvOS)
+    try nib.validate()
+    #endif
+    #if os(iOS) || os(tvOS)
     try storyboard.validate()
     #endif
   }
+
+  #if os(iOS) || os(tvOS)
+  struct nib: Rswift.Validatable {
+    static func validate() throws {
+      try _SearchBar.validate()
+    }
+
+    struct _SearchBar: Rswift.NibResourceType, Rswift.Validatable {
+      let bundle = R.hostingBundle
+      let name = "SearchBar"
+
+      func firstView(owner ownerOrNil: AnyObject?, options optionsOrNil: [UINib.OptionsKey : Any]? = nil) -> UIKit.UIView? {
+        return instantiate(withOwner: ownerOrNil, options: optionsOrNil)[0] as? UIKit.UIView
+      }
+
+      static func validate() throws {
+        if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "clear.fill") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'clear.fill' is used in nib 'SearchBar', but couldn't be loaded.") } }
+        if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "magnifyingglass") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'magnifyingglass' is used in nib 'SearchBar', but couldn't be loaded.") } }
+        if #available(iOS 11.0, tvOS 11.0, *) {
+          if UIKit.UIColor(named: "black2", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'black2' is used in nib 'SearchBar', but couldn't be loaded.") }
+        }
+      }
+
+      fileprivate init() {}
+    }
+
+    fileprivate init() {}
+  }
+  #endif
 
   #if os(iOS) || os(tvOS)
   struct storyboard: Rswift.Validatable {
@@ -395,6 +447,7 @@ struct _R: Rswift.Validatable {
       static func validate() throws {
         if #available(iOS 11.0, tvOS 11.0, *) {
           if UIKit.UIColor(named: "AccentColor", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'AccentColor' is used in storyboard 'Main', but couldn't be loaded.") }
+          if UIKit.UIColor(named: "black2", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'black2' is used in storyboard 'Main', but couldn't be loaded.") }
         }
       }
 

--- a/App/LocationNote/R.generated.swift
+++ b/App/LocationNote/R.generated.swift
@@ -398,6 +398,7 @@ struct _R: Rswift.Validatable {
         if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "clear.fill") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'clear.fill' is used in nib 'SearchBar', but couldn't be loaded.") } }
         if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "magnifyingglass") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'magnifyingglass' is used in nib 'SearchBar', but couldn't be loaded.") } }
         if #available(iOS 11.0, tvOS 11.0, *) {
+          if UIKit.UIColor(named: "Blue1", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'Blue1' is used in nib 'SearchBar', but couldn't be loaded.") }
           if UIKit.UIColor(named: "black1", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'black1' is used in nib 'SearchBar', but couldn't be loaded.") }
           if UIKit.UIColor(named: "black2", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'black2' is used in nib 'SearchBar', but couldn't be loaded.") }
         }

--- a/App/LocationNote/R.generated.swift
+++ b/App/LocationNote/R.generated.swift
@@ -447,8 +447,10 @@ struct _R: Rswift.Validatable {
       let name = "Main"
 
       static func validate() throws {
+        if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "paperplane.fill") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'paperplane.fill' is used in storyboard 'Main', but couldn't be loaded.") } }
+        if #available(iOS 13.0, *) { if UIKit.UIImage(systemName: "plus.circle.fill") == nil { throw Rswift.ValidationError(description: "[R.swift] System image named 'plus.circle.fill' is used in storyboard 'Main', but couldn't be loaded.") } }
         if #available(iOS 11.0, tvOS 11.0, *) {
-          if UIKit.UIColor(named: "AccentColor", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'AccentColor' is used in storyboard 'Main', but couldn't be loaded.") }
+          if UIKit.UIColor(named: "white1", in: R.hostingBundle, compatibleWith: nil) == nil { throw Rswift.ValidationError(description: "[R.swift] Color named 'white1' is used in storyboard 'Main', but couldn't be loaded.") }
         }
       }
 


### PR DESCRIPTION
## 関連
- close #16 

## 概要
- メインのマップ画面のレイアウトを作成
   - 検索欄のカスタムレイアウトを作成
   - Viewに影をつけるExtensionを実装


## スクリーンショット
|対応前|対応後|
|---|---|
|<img width=150 src=""/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/198840139-92593e4a-55d7-402a-8d97-543330136dce.png"/>|



## 動作確認

- [x] ビルドができること
- [x] レイアウトが思ったとおり表示されること
