### PR TITLE
長押しでピンを追加する処理を実装

### DIFF
--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -33,6 +33,7 @@ class MainViewController: BaseViewController {
         addButton.addShadow()
 
         bind()
+        setMapLongPressRecRecognizer()
     }
 
     @IBAction func onLocateButtonTapped(_ sender: Any) {
@@ -55,5 +56,49 @@ extension MainViewController {
             self.mapView.region = region
 
         }).disposed(by: disposeBag)
+    }
+
+    func setMapLongPressRecRecognizer() {
+        let longPressRecognizer: UILongPressGestureRecognizer = UILongPressGestureRecognizer()
+        longPressRecognizer.addTarget(self, action: #selector(self.recognizeLongPress(sender:)))
+
+        mapView.addGestureRecognizer(longPressRecognizer)
+    }
+
+    @objc func recognizeLongPress(sender: UILongPressGestureRecognizer) {
+        // 長押しの最中に何度もピンを生成しないようにする.
+        if sender.state != UIGestureRecognizer.State.began {
+            return
+        }
+
+        let location = sender.location(in: mapView)
+        let coordinate: CLLocationCoordinate2D = mapView.convert(location, toCoordinateFrom: mapView)
+
+        addPin(location: coordinate)
+    }
+
+    func addPin(location: CLLocationCoordinate2D) {
+        let pin: MKPointAnnotation = MKPointAnnotation()
+
+        pin.coordinate = location
+        pin.title = "タイトル"
+        pin.subtitle = "サブタイトル"
+
+        mapView.addAnnotation(pin)
+    }
+
+}
+
+extension MainViewController: MKMapViewDelegate {
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+
+        let pinIdentifier = "PinAnnotationIdentifier"
+        let pinView = MKPinAnnotationView(annotation: annotation, reuseIdentifier: pinIdentifier)
+
+        pinView.animatesDrop = true
+        pinView.canShowCallout = true
+        pinView.annotation = annotation
+
+        return pinView
     }
 }


### PR DESCRIPTION
## 関連
- close #19 

## 概要
- 長押しした地点にピンを追加する。

## スクリーンショット
|押下前|押下後|
|---|---|
|<img width=150 src="https://user-images.githubusercontent.com/17796784/200118108-0f18ec0b-3e9b-49cf-913e-febf92b130d7.png"/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/200118110-3e8d8b58-4de3-4bd2-9071-333f0b4b1644.png"/>|



## 動作確認

- [x] ビルドができること
- [x] 長押しでピンが追加されること

