### PR TITLE
メモ追加画面への遷移を実装

### DIFF
--- a/App/LocationNote/LocationNote.xcodeproj/project.pbxproj
+++ b/App/LocationNote/LocationNote.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		BB59CDA72916840200AB1A2A /* AddMemo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BB59CDA62916840200AB1A2A /* AddMemo.storyboard */; };
 		BB59CDA92916842100AB1A2A /* AddMemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB59CDA82916842100AB1A2A /* AddMemoViewController.swift */; };
 		BB59CDAC29168C1100AB1A2A /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB59CDAB29168C1100AB1A2A /* PrimaryButton.swift */; };
+		BB76C49129169568007C96FC /* NavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB76C49029169568007C96FC /* NavigationViewController.swift */; };
 		BB8F1CE7290D7D05005C97A2 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8F1CE6290D7D05005C97A2 /* ViewExtension.swift */; };
 		BBA94A602906C7B000E9B2F7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA94A5F2906C7B000E9B2F7 /* AppDelegate.swift */; };
 		BBA94A622906C7B000E9B2F7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA94A612906C7B000E9B2F7 /* SceneDelegate.swift */; };
@@ -62,6 +63,7 @@
 		BB59CDA62916840200AB1A2A /* AddMemo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AddMemo.storyboard; sourceTree = "<group>"; };
 		BB59CDA82916842100AB1A2A /* AddMemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMemoViewController.swift; sourceTree = "<group>"; };
 		BB59CDAB29168C1100AB1A2A /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
+		BB76C49029169568007C96FC /* NavigationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewController.swift; sourceTree = "<group>"; };
 		BB8F1CE6290D7D05005C97A2 /* ViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
 		BBA94A5C2906C7B000E9B2F7 /* LocationNote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LocationNote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBA94A5F2906C7B000E9B2F7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -153,6 +155,14 @@
 				BB59CDAB29168C1100AB1A2A /* PrimaryButton.swift */,
 			);
 			path = Button;
+			sourceTree = "<group>";
+		};
+		BB76C48F29169549007C96FC /* Nabigation */ = {
+			isa = PBXGroup;
+			children = (
+				BB76C49029169568007C96FC /* NavigationViewController.swift */,
+			);
+			path = Nabigation;
 			sourceTree = "<group>";
 		};
 		BB8F1CE5290D7CF1005C97A2 /* Extension */ = {
@@ -268,6 +278,7 @@
 		BBF8F7F7290D60D8003C06D1 /* ViewParts */ = {
 			isa = PBXGroup;
 			children = (
+				BB76C48F29169549007C96FC /* Nabigation */,
 				BB59CDAA29168BF200AB1A2A /* Button */,
 				BBF8F7F8290D60EE003C06D1 /* SearchBar */,
 			);
@@ -577,6 +588,7 @@
 				BBF8F7F4290D5F4B003C06D1 /* BaseViewController.swift in Sources */,
 				BBA94A622906C7B000E9B2F7 /* SceneDelegate.swift in Sources */,
 				BBF8F7EA290D5347003C06D1 /* MainRouter.swift in Sources */,
+				BB76C49129169568007C96FC /* NavigationViewController.swift in Sources */,
 				BB21E3B5291629AD00FB0486 /* MainViewmodel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/App/LocationNote/LocationNote/Screen/Base/BaseViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Base/BaseViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class BaseViewController: UIViewController {
 
-    private lazy var router = MainRouter()
+    lazy var router = MainRouter()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/App/LocationNote/LocationNote/Screen/Base/BaseViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Base/BaseViewController.swift
@@ -15,4 +15,8 @@ class BaseViewController: UIViewController {
         super.viewDidLoad()
 
     }
+
+    func modalViewController(_ vc: UIViewController, animated: Bool) {
+        self.present(vc, animated: animated)
+    }
 }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -18,6 +18,7 @@ class MainViewController: BaseViewController {
 
     private var mainViewmodel = MainViewModel()
     private let disposeBag = DisposeBag()
+    private var locationManager = CLLocationManager()
 
     static func initFromStoryboard() -> UIViewController {
         let storyboard = UIStoryboard(name: R.storyboard.main.name, bundle: nil)
@@ -32,6 +33,7 @@ class MainViewController: BaseViewController {
         locateButton.addShadow()
         addButton.addShadow()
 
+        checkLocationPermission()
         bind()
         setMapLongPressRecRecognizer()
     }
@@ -58,6 +60,13 @@ extension MainViewController {
         }).disposed(by: disposeBag)
     }
 
+    func checkLocationPermission() {
+        let status = locationManager.authorizationStatus
+        if status == CLAuthorizationStatus.notDetermined {
+            locationManager.requestWhenInUseAuthorization()
+        }
+    }
+
     func setMapLongPressRecRecognizer() {
         let longPressRecognizer: UILongPressGestureRecognizer = UILongPressGestureRecognizer()
         longPressRecognizer.addTarget(self, action: #selector(self.recognizeLongPress(sender:)))
@@ -74,7 +83,7 @@ extension MainViewController {
         let location = sender.location(in: mapView)
         let coordinate: CLLocationCoordinate2D = mapView.convert(location, toCoordinateFrom: mapView)
 
-        addPin(location: coordinate)
+        navigateToAddMemoScreen()
     }
 
     func addPin(location: CLLocationCoordinate2D) {
@@ -85,6 +94,10 @@ extension MainViewController {
         pin.subtitle = "サブタイトル"
 
         mapView.addAnnotation(pin)
+    }
+
+    func navigateToAddMemoScreen() {
+        self.router.replaceViewController(AddMemoViewController.initFromStoryboard(), animated: true)
     }
 
 }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -97,7 +97,7 @@ extension MainViewController {
     }
 
     func navigateToAddMemoScreen() {
-        self.router.replaceViewController(AddMemoViewController.initFromStoryboard(), animated: true)
+        self.modalViewController(AddMemoViewController.initFromStoryboard(), animated: true)
     }
 
 }

--- a/App/LocationNote/LocationNote/Screen/Memo/AddMemo.storyboard
+++ b/App/LocationNote/LocationNote/Screen/Memo/AddMemo.storyboard
@@ -207,6 +207,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="addButton" destination="pH2-PQ-g1O" id="7b0-Xj-aPA"/>
                         <outlet property="detailTextField" destination="Uad-sN-i3N" id="FxF-F8-huV"/>
                         <outlet property="locationLabel" destination="wni-WF-FCk" id="Csc-Za-42R"/>
                         <outlet property="tagTextField" destination="T2x-rv-vIm" id="Pg5-Nd-EOf"/>

--- a/App/LocationNote/LocationNote/Screen/Memo/AddMemo.storyboard
+++ b/App/LocationNote/LocationNote/Screen/Memo/AddMemo.storyboard
@@ -173,10 +173,9 @@
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pH2-PQ-g1O" customClass="PrimaryButton" customModule="LocationNote" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="342" height="48"/>
+                                                <color key="tintColor" name="white1"/>
                                                 <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="plain" title="追加">
-                                                    <color key="baseForegroundColor" name="white1"/>
-                                                </buttonConfiguration>
+                                                <buttonConfiguration key="configuration" style="plain" title="追加"/>
                                             </button>
                                         </subviews>
                                         <constraints>

--- a/App/LocationNote/LocationNote/Screen/Memo/AddMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Memo/AddMemoViewController.swift
@@ -15,6 +15,8 @@ class AddMemoViewController: BaseViewController {
     @IBOutlet weak var locationLabel: UILabel!
     @IBOutlet weak var addButton: PrimaryButton!
 
+    private var closeButtonItem: UIBarButtonItem!
+
     static func initFromStoryboard() -> UIViewController {
         let storyboard = UIStoryboard(name: R.storyboard.addMemo.name, bundle: nil)
         let viewController = storyboard.instantiateInitialViewController() as! AddMemoViewController
@@ -26,6 +28,16 @@ class AddMemoViewController: BaseViewController {
         super.viewDidLoad()
         title = "メモ追加"
 
+        closeButtonItem = UIBarButtonItem(barButtonSystemItem: .stop, target: self, action: #selector(closeButtonTapped(_:)))
+        closeButtonItem.tintColor = R.color.white1()
+        self.navigationItem.rightBarButtonItem = closeButtonItem
+    }
+
+}
+
+extension AddMemoViewController {
+    @objc func closeButtonTapped(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true)
     }
 
 }

--- a/App/LocationNote/LocationNote/Screen/Memo/AddMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Memo/AddMemoViewController.swift
@@ -15,8 +15,16 @@ class AddMemoViewController: BaseViewController {
     @IBOutlet weak var locationLabel: UILabel!
     @IBOutlet weak var addButton: PrimaryButton!
 
+    static func initFromStoryboard() -> UIViewController {
+        let storyboard = UIStoryboard(name: R.storyboard.addMemo.name, bundle: nil)
+        let viewController = storyboard.instantiateInitialViewController() as! AddMemoViewController
+
+        return NavigationViewController.init(rootViewController: viewController)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        title = "メモ追加"
 
     }
 

--- a/App/LocationNote/LocationNote/ViewParts/Nabigation/NavigationViewController.swift
+++ b/App/LocationNote/LocationNote/ViewParts/Nabigation/NavigationViewController.swift
@@ -1,0 +1,23 @@
+//
+//  NavigationViewController.swift
+//  LocationNote
+//
+//  Created by k17124kk on 2022/11/05.
+//
+
+import UIKit
+
+class NavigationViewController: UINavigationController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let navigationBarAppearance = UINavigationBarAppearance()
+        navigationBarAppearance.configureWithDefaultBackground()
+        navigationBarAppearance.backgroundColor = R.color.blue1()
+        UINavigationBar.appearance().standardAppearance = navigationBarAppearance
+        UINavigationBar.appearance().compactAppearance = navigationBarAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navigationBarAppearance
+
+    }
+}

--- a/App/LocationNote/LocationNote/ViewParts/Nabigation/NavigationViewController.swift
+++ b/App/LocationNote/LocationNote/ViewParts/Nabigation/NavigationViewController.swift
@@ -15,6 +15,7 @@ class NavigationViewController: UINavigationController {
         let navigationBarAppearance = UINavigationBarAppearance()
         navigationBarAppearance.configureWithDefaultBackground()
         navigationBarAppearance.backgroundColor = R.color.blue1()
+        navigationBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.white]
         UINavigationBar.appearance().standardAppearance = navigationBarAppearance
         UINavigationBar.appearance().compactAppearance = navigationBarAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = navigationBarAppearance


### PR DESCRIPTION
## 関連
- close #21 

## 概要
- マップ長押しでメモ追加へモーダル遷移するよう実装
   - NavigationControllerを実装
      - iOS15以降で透過される問題を対応
   - NavigationBarに閉じるボタンを実装

## スクリーンショット
|ボタン非活性時|ボタン活性時|
|---|---|
|<img width=150 src="https://user-images.githubusercontent.com/17796784/200125012-6eabec65-216f-44d3-b9ca-f03cf34ec9da.png"/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/200125014-11f3b1b9-9fb5-4255-9fae-98e6b5b56413.png"/>|

## 動作確認

- [x] ビルドができること
- [x] マップ長押しでメモ追加画面が表示されること
- [x] バツボタン押下で画面が閉じること

