### PR TITLE
【マップ画面】画面表示時に保存済みのピンを表示するよう実装

### DIFF
--- a/App/LocationNote/LocationNote/Model/Data/Memo.swift
+++ b/App/LocationNote/LocationNote/Model/Data/Memo.swift
@@ -8,6 +8,8 @@
 import Foundation
 import CoreLocation
 
+// データ保存用のメモクラス
+// CLLocationCoordinate2DがCodableに対応していないためlat/lonをDoubleで保持
 struct Memo: Codable {
 
     let title: String

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -38,6 +38,12 @@ class MainViewController: BaseViewController {
         setMapLongPressRecRecognizer()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        mainViewmodel.viewDidAppear(location: self.mapView.userLocation.coordinate)
+    }
+
     @IBAction func onLocateButtonTapped(_ sender: Any) {
         mainViewmodel.onLocationButtonTapped(location: self.mapView.userLocation.coordinate)
     }
@@ -57,7 +63,10 @@ extension MainViewController {
             let span = MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
             let region = MKCoordinateRegion(center: location, span: span)
             self.mapView.region = region
+        }).disposed(by: disposeBag)
 
+        mainViewmodel.memoListObservable.bind(onNext: { memoList in
+            self.addPin(mapPinList: memoList)
         }).disposed(by: disposeBag)
     }
 
@@ -87,14 +96,16 @@ extension MainViewController {
         navigateToAddMemoScreen(location: coordinate)
     }
 
-    func addPin(location: CLLocationCoordinate2D) {
-        let pin: MKPointAnnotation = MKPointAnnotation()
+    func addPin(mapPinList: [Memo]) {
+        mapPinList.forEach({
+            let pin: MKPointAnnotation = MKPointAnnotation()
 
-        pin.coordinate = location
-        pin.title = "タイトル"
-        pin.subtitle = "サブタイトル"
+            pin.coordinate = CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+            pin.title = $0.title
+            pin.subtitle = $0.detail
 
-        mapView.addAnnotation(pin)
+            mapView.addAnnotation(pin)
+        })
     }
 
     func navigateToAddMemoScreen(location: CLLocationCoordinate2D) {
@@ -120,6 +131,6 @@ extension MainViewController: MKMapViewDelegate {
 
 extension MainViewController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        print("come back")
+        self.mainViewmodel.onPresentationControllerDidDismiss()
     }
 }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -98,7 +98,8 @@ extension MainViewController {
     }
 
     func navigateToAddMemoScreen(location: CLLocationCoordinate2D) {
-        self.modalViewController(AddMemoViewController.initFromStoryboard(location: location), animated: true)
+        let nextView = AddMemoViewController.initFromStoryboard(location: location, parent: self)
+        self.modalViewController(nextView, animated: true)
     }
 
 }
@@ -114,5 +115,11 @@ extension MainViewController: MKMapViewDelegate {
         pinView.annotation = annotation
 
         return pinView
+    }
+}
+
+extension MainViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        print("come back")
     }
 }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
@@ -32,7 +32,10 @@ final class MainViewModel {
     }
 
     func viewDidAppear(location: CLLocationCoordinate2D) {
-        locationDriver.accept(location)
+        if location.latitude != 0 || location.longitude != 0 {
+            locationDriver.accept(location)
+        }
+
         loadMapPinList()
     }
 

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
@@ -11,6 +11,16 @@ import RxCocoa
 import CoreLocation
 
 final class MainViewModel {
+    private let dataStore = DataStore()
+    private let disposeBag = DisposeBag()
+
+    // Input
+
+    // Output
+    private let _memoListDriver = BehaviorRelay<[Memo]>(value: [])
+    var memoListObservable: Observable<[Memo]> {
+        _memoListDriver.asObservable()
+    }
 
     private var locationDriver = BehaviorRelay<CLLocationCoordinate2D?>(value: nil)
     var locationObservable: Observable<CLLocationCoordinate2D?> {
@@ -21,4 +31,16 @@ final class MainViewModel {
         locationDriver.accept(location)
     }
 
+    func viewDidAppear(location: CLLocationCoordinate2D) {
+        locationDriver.accept(location)
+        loadMapPinList()
+    }
+
+    func onPresentationControllerDidDismiss() {
+        loadMapPinList()
+    }
+
+   private func loadMapPinList() {
+        _memoListDriver.accept(dataStore.loadMemo() ?? [])
+    }
 }

--- a/App/LocationNote/LocationNote/Screen/Memo/AddMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Memo/AddMemoViewController.swift
@@ -25,10 +25,11 @@ class AddMemoViewController: BaseViewController {
 
     private let disposeBag = DisposeBag()
 
-    static func initFromStoryboard(location: CLLocationCoordinate2D) -> UIViewController {
+    static func initFromStoryboard(location: CLLocationCoordinate2D, parent: UIAdaptivePresentationControllerDelegate) -> UIViewController {
         let storyboard = UIStoryboard(name: R.storyboard.addMemo.name, bundle: nil)
         let viewController = storyboard.instantiateInitialViewController() as! AddMemoViewController
         viewController.location = location
+        viewController.presentationController?.delegate = parent
 
         return NavigationViewController.init(rootViewController: viewController)
     }
@@ -45,6 +46,14 @@ class AddMemoViewController: BaseViewController {
 
         setLayout()
         bind()
+    }
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        guard let presentationController = presentationController else {
+            return
+        }
+        presentationController.delegate?.presentationControllerDidDismiss?(presentationController)
+        super.dismiss(animated: flag, completion: completion)
     }
 
 }
@@ -98,6 +107,7 @@ extension AddMemoViewController {
             .asDriver()
             .drive(onNext: {
                 self.addMemoViewModel?.onAddButtonTapped()
+                self.dismiss(animated: true)
             })
             .disposed(by: disposeBag)
 

--- a/App/LocationNote/LocationNote/Util/DataStore.swift
+++ b/App/LocationNote/LocationNote/Util/DataStore.swift
@@ -24,6 +24,10 @@ struct DataStore {
         if let data = UserDefaults.standard.data(forKey: DataStoreKey.MEMO.rawValue) {
             return try? JSONDecoder().decode([Memo].self, from: data)
         }
-        return nil
+        return []
+    }
+
+    func clearMemo() {
+        UserDefaults.standard.set([], forKey: DataStoreKey.MEMO.rawValue)
     }
 }


### PR DESCRIPTION
## 関連
- close #38 

## 概要
- アプリ起動時に保存済みピンをマップに追加する処理を実装
   - アプリ起動時に現在位置を表示するように
- メモ追加画面から戻った場合に保存済みメモを読み込んでマップに追加するよう実装

## スクリーンショット
<img width=150 src=""/>

https://user-images.githubusercontent.com/17796784/201484063-8d2e2675-9a95-4ab5-8529-5b19f7ab7a1b.mov



## 動作確認

- [x] ビルドができること
- [x] アプリ起動時に現在位置が表示されること
- [x] アプリ起動時に保存済みのメモがピンとして表示されること
- [x] メモ追加画面から戻った際にメモが追加されること

