### PR TITLE
【マップ画面】ピンの情報を吹き出しで表示するよう変更

### DIFF
--- a/App/LocationNote/LocationNote/Model/Data/Memo.swift
+++ b/App/LocationNote/LocationNote/Model/Data/Memo.swift
@@ -11,6 +11,7 @@ import CoreLocation
 // データ保存用のメモクラス
 // CLLocationCoordinate2DがCodableに対応していないためlat/lonをDoubleで保持
 struct Memo: Codable {
+    static let SEPARATOR = "\n #"
 
     let title: String
     let detail: String

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -69,6 +69,10 @@ extension MainViewController {
         mainViewmodel.memoListObservable.bind(onNext: { memoList in
             self.addPin(mapPinList: memoList)
         }).disposed(by: disposeBag)
+
+        mainViewmodel.editMemoObservable.bind(onNext: { _ in
+            // TODO 編集画面に画面遷移
+        }).disposed(by: disposeBag)
     }
 
     func checkLocationPermission() {
@@ -97,14 +101,8 @@ extension MainViewController {
         navigateToAddMemoScreen(location: coordinate)
     }
 
-    func addPin(mapPinList: [Memo]) {
-        mapPinList.forEach({
-            let pin: MKPointAnnotation = MKPointAnnotation()
-
-            pin.coordinate = CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
-            pin.title = $0.title
-            pin.subtitle = $0.detail
-
+    func addPin(mapPinList: [MKAnnotation]) {
+        mapPinList.forEach({ pin in
             mapView.addAnnotation(pin)
         })
     }
@@ -136,7 +134,7 @@ extension MainViewController: MKMapViewDelegate {
     }
 
     func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView, calloutAccessoryControlTapped control: UIControl) {
-        print("\(view.annotation?.title) \(view.annotation?.subtitle) \(control)")
+        mainViewmodel.onCalloutAccessoryTapped(annotation: view.annotation!)
     }
 }
 

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -29,6 +29,7 @@ class MainViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        mapView.delegate = self
 
         locateButton.addShadow()
         addButton.addShadow()
@@ -117,15 +118,25 @@ extension MainViewController {
 
 extension MainViewController: MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        guard annotation as? MKUserLocation != mapView.userLocation else { return nil }
 
         let pinIdentifier = "PinAnnotationIdentifier"
         let pinView = MKPinAnnotationView(annotation: annotation, reuseIdentifier: pinIdentifier)
 
         pinView.animatesDrop = true
         pinView.canShowCallout = true
-        pinView.annotation = annotation
 
         return pinView
+    }
+
+    func mapView(_ mapView: MKMapView, didAdd views: [MKAnnotationView]) {
+        for view in views {
+            view.rightCalloutAccessoryView = UIButton(type: .detailDisclosure)
+        }
+    }
+
+    func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView, calloutAccessoryControlTapped control: UIControl) {
+        print("\(view.annotation?.title) \(view.annotation?.subtitle) \(control)")
     }
 }
 

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -123,6 +123,7 @@ extension MainViewController: MKMapViewDelegate {
 
         pinView.animatesDrop = true
         pinView.canShowCallout = true
+        pinView.annotation = annotation
 
         return pinView
     }


### PR DESCRIPTION
## 関連
- close #46 

## 概要
- ピンのタイトルやサブタイトルを吹き出しで表示するよう修正
   - delegateを設定していなかった
- 吹き出しにボタンを設置し編集画面に遷移できるよう実装
- 編集画面に遷移できるようViewModelにMKAnnotatioからMemoに変換する処理を実装
   - MKAnnotationではtagを持てないため、subtitleに詳細とタグを持つようセパレータで統合するように。

## スクリーンショット
|対応前|対応後|
|---|---|
|<img width=150 src=""/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/202857564-d677ec41-cce3-49d4-a39e-e1b16206b691.png"/>|


## 動作確認

- [x] ビルドができること
- [x] ピンの詳細が吹き出しで表示されること
- [x] ボタン押下で情報がMemoとして取得できること

