### PR TITLE
【編集画面】削除ボタン押下時の処理を実装

### DIFF
--- a/App/LocationNote/LocationNote/Screen/Base/BaseViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Base/BaseViewController.swift
@@ -20,3 +20,26 @@ class BaseViewController: UIViewController {
         self.present(vc, animated: animated)
     }
 }
+
+protocol AleratTappedListener: AnyObject {
+    func onConfirmButtonTapped()
+    func onCancellButtonTapped()
+}
+
+extension BaseViewController {
+
+    func showAleart(title: String, subtitle: String?, confirmButtonTitle: String, onConfirm: @escaping () -> Void) {
+        let alert: UIAlertController = UIAlertController(title: title, message: subtitle, preferredStyle: UIAlertController.Style.alert)
+
+        let confirmAction: UIAlertAction = UIAlertAction(title: confirmButtonTitle, style: UIAlertAction.Style.default, handler: {(_: UIAlertAction!) -> Void in
+            onConfirm()
+        })
+
+        let cancelAction: UIAlertAction = UIAlertAction(title: "キャンセル", style: UIAlertAction.Style.cancel, handler: { _ in})
+
+        alert.addAction(cancelAction)
+        alert.addAction(confirmAction)
+
+        present(alert, animated: true, completion: nil)
+    }
+}

--- a/App/LocationNote/LocationNote/Screen/Base/BaseViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Base/BaseViewController.swift
@@ -21,11 +21,6 @@ class BaseViewController: UIViewController {
     }
 }
 
-protocol AleratTappedListener: AnyObject {
-    func onConfirmButtonTapped()
-    func onCancellButtonTapped()
-}
-
 extension BaseViewController {
 
     func showAleart(title: String, subtitle: String?, confirmButtonTitle: String, onConfirm: @escaping () -> Void) {

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.storyboard
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.storyboard
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
-    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -15,33 +13,33 @@
             <objects>
                 <viewController id="Y6W-OH-hqX" customClass="EditMemoViewController" customModule="LocationNote" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Qdh-A3-MIq">
-                                <rect key="frame" x="24" y="59" width="345" height="759"/>
+                                <rect key="frame" x="24" y="0.0" width="552" height="600"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DM2-Yc-hNL" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="0.0" width="345" height="36"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="552" height="36"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="36" id="whu-HT-h2n"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0zN-9m-94r" userLabel="title">
-                                        <rect key="frame" x="0.0" y="36" width="345" height="56"/>
+                                        <rect key="frame" x="0.0" y="36" width="552" height="56"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="250-Eq-lkL">
-                                                <rect key="frame" x="0.0" y="0.0" width="345" height="56"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="552" height="56"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="タイトル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GwQ-nu-tRL">
-                                                        <rect key="frame" x="0.0" y="0.0" width="345" height="14"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="552" height="14"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" name="black2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="253" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="タイトルを入力" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tkr-kz-7FR">
-                                                        <rect key="frame" x="0.0" y="22" width="345" height="34"/>
+                                                        <rect key="frame" x="0.0" y="22" width="552" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                     </textField>
@@ -57,26 +55,26 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fmn-LE-5tK" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="92" width="345" height="24"/>
+                                        <rect key="frame" x="0.0" y="92" width="552" height="24"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="24" id="Ee5-Ni-Ry2"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hla-eQ-YK3" userLabel="memo">
-                                        <rect key="frame" x="0.0" y="116" width="345" height="357"/>
+                                        <rect key="frame" x="0.0" y="116" width="552" height="198"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="a8i-nI-vDS">
-                                                <rect key="frame" x="0.0" y="0.0" width="345" height="357"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="552" height="198"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="詳細" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbq-PC-o5e">
-                                                        <rect key="frame" x="0.0" y="0.0" width="345" height="17"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="552" height="0.0"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" name="black2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="l7x-9B-Cz5">
-                                                        <rect key="frame" x="0.0" y="25" width="345" height="332"/>
+                                                        <rect key="frame" x="0.0" y="8" width="552" height="190"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <color key="textColor" systemColor="labelColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -93,26 +91,26 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E8j-wY-rvo" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="473" width="345" height="24"/>
+                                        <rect key="frame" x="0.0" y="314" width="552" height="24"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="24" id="qdl-CM-qKY"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="teN-ZP-N0X" userLabel="tag">
-                                        <rect key="frame" x="0.0" y="497" width="345" height="56"/>
+                                        <rect key="frame" x="0.0" y="338" width="552" height="56"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="39e-iV-Fzw">
-                                                <rect key="frame" x="0.0" y="0.0" width="345" height="56"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="552" height="56"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="タグ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oVB-rI-eRg">
-                                                        <rect key="frame" x="0.0" y="0.0" width="345" height="14"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="552" height="14"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" name="black2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="タグを入力('#'で区切ってください)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="03i-ev-hZp">
-                                                        <rect key="frame" x="0.0" y="22" width="345" height="34"/>
+                                                        <rect key="frame" x="0.0" y="22" width="552" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                     </textField>
@@ -128,26 +126,26 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ane-8m-a5V" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="553" width="345" height="24"/>
+                                        <rect key="frame" x="0.0" y="394" width="552" height="24"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="24" id="ZGc-Yi-Ehd"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rgV-3Q-RCi" userLabel="lat_lon">
-                                        <rect key="frame" x="0.0" y="577" width="345" height="60"/>
+                                        <rect key="frame" x="0.0" y="418" width="552" height="60"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="83s-5u-diN">
-                                                <rect key="frame" x="0.0" y="0.0" width="345" height="60"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="552" height="60"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="緯度経度" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vye-Na-tVs">
-                                                        <rect key="frame" x="0.0" y="0.0" width="345" height="15.666666666666666"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="552" height="15.666666666666666"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <color key="textColor" name="black2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="753" text="35.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lGx-xt-NS6">
-                                                        <rect key="frame" x="0.0" y="23.666666666666632" width="345" height="36.333333333333343"/>
+                                                        <rect key="frame" x="0.0" y="23.666666666666689" width="552" height="36.333333333333343"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -164,17 +162,17 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZJ1-YM-K0m" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="637" width="345" height="50"/>
+                                        <rect key="frame" x="0.0" y="478" width="552" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="50" id="9pL-z2-Zeb"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oFa-8t-7SN" userLabel="button">
-                                        <rect key="frame" x="0.0" y="687" width="345" height="48"/>
+                                        <rect key="frame" x="0.0" y="528" width="552" height="48"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eFt-XR-Csg" customClass="PrimaryButton" customModule="LocationNote" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="345" height="48"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="552" height="48"/>
                                                 <color key="tintColor" name="white1"/>
                                                 <state key="normal" title="Button"/>
                                                 <buttonConfiguration key="configuration" style="plain" title="変更"/>
@@ -189,7 +187,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AqX-rL-rz2" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="735" width="345" height="24"/>
+                                        <rect key="frame" x="0.0" y="576" width="552" height="24"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="24" id="yhW-Es-lgw"/>
@@ -208,8 +206,8 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="addButton" destination="eFt-XR-Csg" id="enG-GM-JTg"/>
                         <outlet property="detailTextView" destination="l7x-9B-Cz5" id="A7p-kd-zuQ"/>
+                        <outlet property="editButton" destination="eFt-XR-Csg" id="enG-GM-JTg"/>
                         <outlet property="locationLabel" destination="lGx-xt-NS6" id="bNi-Qp-xoj"/>
                         <outlet property="tagTextField" destination="03i-ev-hZp" id="Lf4-6O-Qex"/>
                         <outlet property="titleTextField" destination="tkr-kz-7FR" id="dYc-EZ-IbY"/>

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import CoreLocation
 
+// MARK: LifeCycle
 class EditMemoViewController: BaseViewController {
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var detailTextView: UITextView!
@@ -36,26 +37,10 @@ class EditMemoViewController: BaseViewController {
         setNavigationBarItem()
         setLayout()
     }
-
-    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        guard let presentationController = presentationController else {
-            return
-        }
-        presentationController.delegate?.presentationControllerDidDismiss?(presentationController)
-        super.dismiss(animated: flag, completion: completion)
-    }
 }
 
+// MARK: Layout
 extension EditMemoViewController {
-    @objc func closeButtonTapped(_ sender: UIBarButtonItem) {
-        self.dismiss(animated: true)
-    }
-
-    @objc func deleteButtonTapped(_ sender: UIBarButtonItem) {
-        let deleteMemo = Memo(title: titleTextField.text ?? "", detail: detailTextView.text ?? "", tag: tagTextField.text ?? "", latitude: self.memo!.latitude, longitude: self.memo!.longitude)
-        viewModel.onDeleteButtonTapped(memo: deleteMemo)
-        self.dismiss(animated: true)
-    }
 
     func setNavigationBarItem() {
         let closeButtonItem = UIBarButtonItem(barButtonSystemItem: .stop, target: self, action: #selector(closeButtonTapped(_:)))
@@ -84,6 +69,31 @@ extension EditMemoViewController {
         tagTextField.layer.borderWidth = 1
         tagTextField.layer.cornerRadius = 4
         tagTextField.text = memo?.tag
+    }
+}
 
+// MARK: Navigation View Button
+extension EditMemoViewController{
+    
+    @objc func closeButtonTapped(_ sender: UIBarButtonItem) {
+        self.dismiss(animated: true)
+    }
+
+    @objc func deleteButtonTapped(_ sender: UIBarButtonItem) {
+        self.showAleart(title: "このメモを削除しますか？", subtitle: nil, confirmButtonTitle: "削除", onConfirm: { self.dismissWithDelete() })
+    }
+    
+    func dismissWithDelete() {
+        let deleteMemo = Memo(title: titleTextField.text ?? "", detail: detailTextView.text ?? "", tag: tagTextField.text ?? "", latitude: self.memo!.latitude, longitude: self.memo!.longitude)
+        viewModel.onDeleteButtonTapped(memo: deleteMemo)
+        self.dismiss(animated: true)
+    }
+    
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        guard let presentationController = presentationController else {
+            return
+        }
+        presentationController.delegate?.presentationControllerDidDismiss?(presentationController)
+        super.dismiss(animated: flag, completion: completion)
     }
 }

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
@@ -36,6 +36,14 @@ class EditMemoViewController: BaseViewController {
         setNavigationBarItem()
         setLayout()
     }
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        guard let presentationController = presentationController else {
+            return
+        }
+        presentationController.delegate?.presentationControllerDidDismiss?(presentationController)
+        super.dismiss(animated: flag, completion: completion)
+    }
 }
 
 extension EditMemoViewController {
@@ -44,6 +52,8 @@ extension EditMemoViewController {
     }
 
     @objc func deleteButtonTapped(_ sender: UIBarButtonItem) {
+        let deleteMemo = Memo(title: titleTextField.text ?? "", detail: detailTextView.text ?? "", tag: tagTextField.text ?? "", latitude: self.memo!.latitude, longitude: self.memo!.longitude)
+        viewModel.onDeleteButtonTapped(memo: deleteMemo)
         self.dismiss(animated: true)
     }
 

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
@@ -8,5 +8,9 @@
 import Foundation
 
 final class EditMemoViewModel {
+    private let dataStore = DataStore()
 
+    func onDeleteButtonTapped(memo: Memo) {
+        dataStore.deleteMemo(memo: memo)
+    }
 }

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
@@ -6,11 +6,53 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
 
 final class EditMemoViewModel {
+    private var memo: Memo
+
+    // Input
+    private let _title = BehaviorSubject<String>(value: "")
+    var title: AnyObserver<String> {
+        _title.asObserver()
+    }
+
+    private let _detail = BehaviorSubject<String>(value: "")
+    var detail: AnyObserver<String> {
+        _detail.asObserver()
+    }
+
+    private let _tag = BehaviorSubject<String>(value: "")
+    var tag: AnyObserver<String> {
+        _tag.asObserver()
+    }
+
+    // OutPut
+    private let _buttonEnabled = BehaviorRelay<Bool>(value: false)
+    var buttonEnabled: Driver<Bool> {
+        _buttonEnabled.asDriver()
+    }
+
+    private let disposeBag = DisposeBag()
     private let dataStore = DataStore()
 
-    func onDeleteButtonTapped(memo: Memo) {
+    init(memo: Memo) {
+        self.memo = memo
+
+        _title.asObserver()
+            .map({!$0.isEmpty})
+            .bind(to: _buttonEnabled)
+            .disposed(by: disposeBag)
+    }
+
+    func onDeleteButtonTapped() {
+        guard let title = try? _title.value(), let detail = try? _detail.value(), let tag = try? _tag.value() else {
+            return
+        }
+
+        let memo = Memo.init(title: title, detail: detail, tag: tag, latitude: memo.latitude, longitude: memo.longitude)
+
         dataStore.deleteMemo(memo: memo)
     }
 }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -19,6 +19,7 @@ class MainViewController: BaseViewController {
     private var mainViewmodel = MainViewModel()
     private let disposeBag = DisposeBag()
     private var locationManager = CLLocationManager()
+    private var showingAnnotationList: [MKPointAnnotation] = []
 
     static func initFromStoryboard() -> UIViewController {
         let storyboard = UIStoryboard(name: R.storyboard.main.name, bundle: nil)
@@ -68,6 +69,7 @@ extension MainViewController {
 
         mainViewmodel.memoListObservable.bind(onNext: { memoList in
             self.addPin(mapPinList: memoList)
+            self.showingAnnotationList = memoList
         }).disposed(by: disposeBag)
 
         mainViewmodel.editMemoObservable.bind(onNext: { memo in
@@ -105,6 +107,7 @@ extension MainViewController {
     }
 
     func addPin(mapPinList: [MKAnnotation]) {
+        mapView.removeAnnotations(showingAnnotationList)
         mapPinList.forEach({ pin in
             mapView.addAnnotation(pin)
         })

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
@@ -18,8 +18,8 @@ final class MainViewModel {
     // Input
 
     // Output
-    private let _memoListDriver = BehaviorRelay<[MKAnnotation]>(value: [])
-    var memoListObservable: Observable<[MKAnnotation]> {
+    private let _memoListDriver = BehaviorRelay<[MKPointAnnotation]>(value: [])
+    var memoListObservable: Observable<[MKPointAnnotation]> {
         _memoListDriver.asObservable()
     }
 
@@ -50,7 +50,7 @@ final class MainViewModel {
     }
 
    private func loadMapPinList() {
-       var annotationArray: [MKAnnotation] = []
+       var annotationArray: [MKPointAnnotation] = []
        let savedMemoList = dataStore.loadMemo() ?? []
 
        savedMemoList.forEach { memo in

--- a/App/LocationNote/LocationNote/Util/DataStore.swift
+++ b/App/LocationNote/LocationNote/Util/DataStore.swift
@@ -20,11 +20,33 @@ struct DataStore {
         UserDefaults.standard.set(memoList, forKey: DataStoreKey.MEMO.rawValue)
     }
 
+    func saveMmemoList(memoList: [Memo]) {
+       clearMemo()
+        guard let memoList = try? JSONEncoder().encode(memoList) else { return }
+        UserDefaults.standard.set(memoList, forKey: DataStoreKey.MEMO.rawValue)
+    }
+
     func loadMemo() -> [Memo]? {
         if let data = UserDefaults.standard.data(forKey: DataStoreKey.MEMO.rawValue) {
             return try? JSONDecoder().decode([Memo].self, from: data)
         }
         return []
+    }
+
+    func deleteMemo(memo: Memo) {
+        var data = loadMemo()
+        if data?.count == 0 {
+            return
+        }
+
+        guard let index = data?.firstIndex(where: {$0.latitude.isEqual(to: memo.latitude) && $0.longitude.isEqual(to: memo.longitude)
+        }) else {
+            return
+        }
+
+        data?.remove(at: index)
+
+        saveMmemoList(memoList: data ?? [])
     }
 
     func clearMemo() {


### PR DESCRIPTION
## 関連
- close #52 

## 概要
- DataStoreに処理を追加
    - 削除処理
    - リストごと更新
- アラート表示処理を実装
- 削除ボタン押下で削除実施
   - マップ画面に戻ること
   - ピンを一度削除し、更新されたリストのピンを再度追加するよう変更

## スクリーンショット
|削除前|アラート表示|削除後|
|---|---|---|
|<img width=150 src="https://user-images.githubusercontent.com/17796784/202902827-e5063ee0-7aa6-424b-821d-10b9183e7117.png"/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/202902833-39a6c328-a477-4030-8380-53f5909a060b.png"/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/202902834-47862a03-8d91-42f5-a069-9e79cdf0b1a5.png"/>|

## 動作確認

- [x] ビルドができること
- [x] 削除ボタ農家時にアラートが表示されること
- [x] アラートの削除ボタン押下で削除が実行され、マップ画面でピンが削除されていること
- [x] アラートのキャンセル押下で何も起こらないこと

