### PR TITLE
【編集画面】メモの編集機能を実装

### DIFF
--- a/App/LocationNote/LocationNote/Model/Data/Memo.swift
+++ b/App/LocationNote/LocationNote/Model/Data/Memo.swift
@@ -13,9 +13,9 @@ import CoreLocation
 struct Memo: Codable {
     static let SEPARATOR = "\n #"
 
-    let title: String
-    let detail: String
-    let tag: String
+    var title: String
+    var detail: String
+    var tag: String
     let latitude: Double
     let longitude: Double
 }

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
@@ -124,7 +124,7 @@ extension EditMemoViewController {
         editButton.rx.tap
             .asDriver()
             .drive(onNext: {
-//                self.viewModel?.onAddButtonTapped()
+                self.viewModel?.onEditButtonTapped()
                 self.dismiss(animated: true)
             })
             .disposed(by: disposeBag)

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
@@ -45,14 +45,28 @@ final class EditMemoViewModel {
             .bind(to: _buttonEnabled)
             .disposed(by: disposeBag)
     }
+}
 
-    func onDeleteButtonTapped() {
+extension EditMemoViewModel {
+    func createMemo() -> Memo? {
         guard let title = try? _title.value(), let detail = try? _detail.value(), let tag = try? _tag.value() else {
-            return
+            return nil
         }
 
-        let memo = Memo.init(title: title, detail: detail, tag: tag, latitude: memo.latitude, longitude: memo.longitude)
+        return Memo.init(title: title, detail: detail, tag: tag, latitude: memo.latitude, longitude: memo.longitude)
+    }
 
+    func onDeleteButtonTapped() {
+        guard let memo = createMemo() else {
+            return
+        }
         dataStore.deleteMemo(memo: memo)
+    }
+
+    func onEditButtonTapped() {
+        guard let memo = createMemo() else {
+            return
+        }
+        dataStore.editMemo(memo: memo)
     }
 }

--- a/App/LocationNote/LocationNote/Util/DataStore.swift
+++ b/App/LocationNote/LocationNote/Util/DataStore.swift
@@ -26,6 +26,23 @@ struct DataStore {
         UserDefaults.standard.set(memoList, forKey: DataStoreKey.MEMO.rawValue)
     }
 
+    func editMemo(memo: Memo) {
+        var data = loadMemo()
+        if data?.count == 0 {
+            return
+        }
+        guard let index = data?.firstIndex(where: {$0.latitude.isEqual(to: memo.latitude) && $0.longitude.isEqual(to: memo.longitude)
+        }) else {
+            return
+        }
+
+        data?[index].title = memo.title
+        data?[index].detail = memo.detail
+        data?[index].tag = memo.tag
+
+        saveMmemoList(memoList: data ?? [])
+    }
+
     func loadMemo() -> [Memo]? {
         if let data = UserDefaults.standard.data(forKey: DataStoreKey.MEMO.rawValue) {
             return try? JSONDecoder().decode([Memo].self, from: data)


### PR DESCRIPTION
## 関連
- close #53 

## 概要
- DataStoreに編集処理を実装
- 編集ボタン押下でメモの編集を実施

## スクリーンショット
|編集前|編集中|編集後|
|---|---|---|
|<img width=150 src="https://user-images.githubusercontent.com/17796784/202903803-e26f4129-e787-4eb4-937b-ec0a30b25480.png"/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/202903807-1d845be7-7633-4759-933d-0bcf0f86c629.png"/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/202903813-ce050e1a-289f-49cf-9411-6f746a7a2fe0.png"/>|

## 動作確認

- [x] ビルドができること
- [x] 編集後ピンの内容が変わっていること

