### PR TITLE
【マップ画面】位置情報を常に取得するよう実装

### DIFF
--- a/App/LocationNote/LocationNote.xcodeproj/project.pbxproj
+++ b/App/LocationNote/LocationNote.xcodeproj/project.pbxproj
@@ -830,6 +830,7 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LocationNote/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "メモに関する通知を出すために利用します";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -862,6 +863,7 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LocationNote/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "メモに関する通知を出すために利用します";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;

--- a/App/LocationNote/LocationNote.xcodeproj/xcshareddata/xcschemes/LocationNote.xcscheme
+++ b/App/LocationNote/LocationNote.xcodeproj/xcshareddata/xcschemes/LocationNote.xcscheme
@@ -61,6 +61,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/App/LocationNote/LocationNote/Info.plist
+++ b/App/LocationNote/LocationNote/Info.plist
@@ -2,8 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>メモに関する通知を出すために利用します</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>通知を出すのに位置情報を利用します。</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>通知を出すのに位置情報を利用します。</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -23,5 +25,9 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 </dict>
 </plist>

--- a/App/LocationNote/LocationNote/Info.plist
+++ b/App/LocationNote/LocationNote/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>This app uses locaion information for testing</string>
+	<string>メモに関する通知を出すために利用します</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -81,10 +81,15 @@ extension MainViewController {
     }
 
     func checkLocationPermission() {
-        let status = locationManager.authorizationStatus
-        if status == CLAuthorizationStatus.notDetermined {
-            locationManager.requestWhenInUseAuthorization()
+        locationManager.requestAlwaysAuthorization()
+        locationManager.requestWhenInUseAuthorization()
+
+        if CLLocationManager.locationServicesEnabled() {
+            locationManager.delegate = self
+            locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+            locationManager.startUpdatingLocation()
         }
+
     }
 
     func setMapLongPressRecRecognizer() {
@@ -153,5 +158,14 @@ extension MainViewController: MKMapViewDelegate {
 extension MainViewController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         self.mainViewmodel.onPresentationControllerDidDismiss()
+    }
+}
+
+extension MainViewController: CLLocationManagerDelegate {
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+
+        guard let locValue: CLLocationCoordinate2D = manager.location?.coordinate else { return }
+        print("locations = \(locValue.latitude) \(locValue.longitude)")
     }
 }


### PR DESCRIPTION
## 関連
- close #48 

## 概要
常に位置情報を取得する
- info.plistに権限取得することを追加
- 位置情報権限の取得状況に応じて処理を変えるよう実装
   - 途中で権限が変更しても対応できるよう
- アプリがクラッシュしないよう実装
   - バックグラウンドにした際にクラッシュしないよう対応
      - 参考：https://developer.apple.com/forums/thread/699119
   - 一度のみ許可したあと、バックグラウンドにして時間をおいたあとに現在位置ボタンを押すとクラシュする
      - 位置情報の取得のエラー時にはダイアログを表示して何もしないように対応


## 動作確認

- [x] ビルドができること
- [x] アプリがバックグラウンドでも位置情報が取得できていること
   - コンソールで確認 
- [x] アプリがクラッシュしないこと

