### PR TITLE
【マップ画面】位置情報がピンの近くにあるかの判定を行う処理を実装

### DIFF
--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -42,10 +42,6 @@ class MainViewController: BaseViewController {
         checkLocationPermission()
         bind()
         setMapLongPressRecRecognizer()
-
-        NotificationCenter.default.addObserver(self, selector: #selector(toForeGround(notification:)), name: UIApplication.willEnterForegroundNotification, object: nil)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(toBackGround(notification:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -171,15 +167,6 @@ extension MainViewController {
         }
         return determinedPin
     }
-
-    @objc func toForeGround(notification: Notification) {
-        print("フォアグラウンド")
-    }
-
-    @objc func toBackGround(notification: Notification) {
-        print("バックグラウンド")
-    }
-
 }
 
 // MARK: MKMapViewDelegate

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -21,8 +21,6 @@ class MainViewController: BaseViewController {
     private var showingAnnotationList: [MKPointAnnotation] = []
 
     private let disposeBag = DisposeBag()
-    // ピントとの距離が近いと判定する範囲
-    private let DETERMINE_AREA: Double = 80.0
 
     static func initFromStoryboard() -> UIViewController {
         let storyboard = UIStoryboard(name: R.storyboard.main.name, bundle: nil)
@@ -148,25 +146,7 @@ extension MainViewController {
         self.modalViewController(nextView, animated: true)
     }
 
-    // 近いピンがあるか判定を行う
-    func determineNearbyPin(location: CLLocationCoordinate2D) -> MKPointAnnotation? {
-        var determinedPin: MKPointAnnotation?
-
-        if showingAnnotationList.isEmpty {
-            return nil
-        }
-
-        let clLocation = CLLocation(latitude: location.latitude, longitude: location.longitude)
-        showingAnnotationList.forEach { pin in
-            let pinLocation = CLLocation(latitude: pin.coordinate.latitude, longitude: pin.coordinate.longitude)
-            let distance = clLocation.distance(from: pinLocation)
-
-            if distance < DETERMINE_AREA {
-                determinedPin =  pin
-            }
-        }
-        return determinedPin
-    }
+    
 }
 
 // MARK: MKMapViewDelegate
@@ -211,7 +191,7 @@ extension MainViewController: CLLocationManagerDelegate {
             guard let locValue: CLLocationCoordinate2D = manager.location?.coordinate else { return }
             print("locations = \(locValue.latitude) \(locValue.longitude)")
 
-            print(self.determineNearbyPin(location: locValue))
+            print(mainViewmodel.determineNearbyPin(location: locValue))
         }
 
     }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -85,6 +85,14 @@ extension MainViewController {
             }
             self.navigateToEditMemoScreen(memo: memo)
         }).disposed(by: disposeBag)
+
+        mainViewmodel.nearbyPinObservable.bind(onNext: { pin in
+            guard let nearbyPin = pin else {
+                return
+            }
+            // TODO 通知出す?
+            print(nearbyPin)
+        }).disposed(by: disposeBag)
     }
 
     func checkLocationPermission() {
@@ -146,7 +154,6 @@ extension MainViewController {
         self.modalViewController(nextView, animated: true)
     }
 
-    
 }
 
 // MARK: MKMapViewDelegate
@@ -191,7 +198,7 @@ extension MainViewController: CLLocationManagerDelegate {
             guard let locValue: CLLocationCoordinate2D = manager.location?.coordinate else { return }
             print("locations = \(locValue.latitude) \(locValue.longitude)")
 
-            print(mainViewmodel.determineNearbyPin(location: locValue))
+            mainViewmodel.didUpdateLocations(location: locValue)
         }
 
     }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -28,6 +28,7 @@ class MainViewController: BaseViewController {
         return viewController
     }
 
+// MARK: Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         mapView.delegate = self
@@ -38,6 +39,10 @@ class MainViewController: BaseViewController {
         checkLocationPermission()
         bind()
         setMapLongPressRecRecognizer()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(toForeGround(notification:)), name: UIApplication.willEnterForegroundNotification, object: nil)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(toBackGround(notification:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -59,6 +64,7 @@ class MainViewController: BaseViewController {
     }
 }
 
+// MARK: Methods
 extension MainViewController {
     func bind() {
         mainViewmodel.locationObservable.bind(onNext: { location in
@@ -142,8 +148,17 @@ extension MainViewController {
         self.modalViewController(nextView, animated: true)
     }
 
+    @objc func toForeGround(notification: Notification) {
+        print("フォアグラウンド")
+    }
+
+    @objc func toBackGround(notification: Notification) {
+        print("バックグラウンド")
+    }
+
 }
 
+// MARK: MKMapViewDelegate
 extension MainViewController: MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
         guard annotation as? MKUserLocation != mapView.userLocation else { return nil }
@@ -169,12 +184,14 @@ extension MainViewController: MKMapViewDelegate {
     }
 }
 
+// MARK: UIAdaptivePresentationControllerDelegate
 extension MainViewController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         self.mainViewmodel.onPresentationControllerDidDismiss()
     }
 }
 
+// MARK: CLLocationManagerDelegate
 extension MainViewController: CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
@@ -14,6 +14,8 @@ import MapKit
 final class MainViewModel {
     private let dataStore = DataStore()
     private let disposeBag = DisposeBag()
+    // ピントとの距離が近いと判定する範囲
+    private let DETERMINE_AREA: Double = 80.0
 
     // Input
 
@@ -75,5 +77,25 @@ final class MainViewModel {
         memo = Memo(title: (annotation.title ?? "") ?? "", detail: detailTagArray?[0] ?? "", tag: detailTagArray?[1] ?? "", latitude: annotation.coordinate.latitude, longitude: annotation.coordinate.longitude)
 
         _editMemoDriver.accept(memo)
+    }
+    
+    // 近いピンがあるか判定を行う
+    func didUpdateLocations(location: CLLocationCoordinate2D) -> MKPointAnnotation? {
+        var determinedPin: MKPointAnnotation?
+
+        if _memoListDriver.value.isEmpty {
+            return nil
+        }
+
+        let clLocation = CLLocation(latitude: location.latitude, longitude: location.longitude)
+        _memoListDriver.value.forEach { pin in
+            let pinLocation = CLLocation(latitude: pin.coordinate.latitude, longitude: pin.coordinate.longitude)
+            let distance = clLocation.distance(from: pinLocation)
+
+            if distance < DETERMINE_AREA {
+                determinedPin =  pin
+            }
+        }
+        return determinedPin
     }
 }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
@@ -35,6 +35,11 @@ final class MainViewModel {
         _editMemoDriver.asObservable()
     }
 
+    private var _nearbyPinDriver = BehaviorRelay<MKPointAnnotation?>(value: nil)
+    var nearbyPinObservable: Observable<MKPointAnnotation?> {
+        _nearbyPinDriver.asObservable()
+    }
+
     func onLocationButtonTapped(location: CLLocationCoordinate2D) {
         locationDriver.accept(location)
     }
@@ -78,13 +83,11 @@ final class MainViewModel {
 
         _editMemoDriver.accept(memo)
     }
-    
-    // 近いピンがあるか判定を行う
-    func didUpdateLocations(location: CLLocationCoordinate2D) -> MKPointAnnotation? {
-        var determinedPin: MKPointAnnotation?
 
+    // 近いピンがあるか判定を行う
+    func didUpdateLocations(location: CLLocationCoordinate2D) {
         if _memoListDriver.value.isEmpty {
-            return nil
+            return
         }
 
         let clLocation = CLLocation(latitude: location.latitude, longitude: location.longitude)
@@ -93,9 +96,9 @@ final class MainViewModel {
             let distance = clLocation.distance(from: pinLocation)
 
             if distance < DETERMINE_AREA {
-                determinedPin =  pin
+                _nearbyPinDriver.accept(pin)
+                return
             }
         }
-        return determinedPin
     }
 }


### PR DESCRIPTION
## 関連
- close #50 

## 概要
- 位置情報が更新されるたびにピンとの距離判定を行う。
   - 近いピンがあればVC側に通知
   - 距離は一旦80mにしている

## 動作確認

- [x] ビルドができること
- [x] 現在位置が近くなった際にピンの情報が渡されること

