### PR TITLE
アプリキル状態でも位置の判定と通知が行えるよう実装

### DIFF
--- a/App/LocationNote/LocationNote.xcodeproj/project.pbxproj
+++ b/App/LocationNote/LocationNote.xcodeproj/project.pbxproj
@@ -830,6 +830,8 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LocationNote/Info.plist;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "通知を出すのに位置情報を利用します。";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "通知を出すのに位置情報を利用します。";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "メモに関する通知を出すために利用します";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;
@@ -863,6 +865,8 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LocationNote/Info.plist;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "通知を出すのに位置情報を利用します。";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "通知を出すのに位置情報を利用します。";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "メモに関する通知を出すために利用します";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;

--- a/App/LocationNote/LocationNote/Info.plist
+++ b/App/LocationNote/LocationNote/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>通知を出すのに位置情報を利用します。</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>通知を出すのに位置情報を利用します。</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/App/LocationNote/LocationNote/Info.plist
+++ b/App/LocationNote/LocationNote/Info.plist
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>通知を出すのに位置情報を利用します。</string>
 	<key>NSLocationAlwaysUsageDescription</key>
+	<string>通知を出すのに位置情報を利用します。</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>通知を出すのに位置情報を利用します。</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
@@ -15,7 +15,7 @@ final class MainViewModel {
     private let dataStore = DataStore()
     private let disposeBag = DisposeBag()
     // ピントとの距離が近いと判定する範囲
-    private let DETERMINE_AREA: Double = 80.0
+    static let DETERMINE_AREA: Double = 80.0
 
     // Input
 
@@ -95,7 +95,7 @@ final class MainViewModel {
             let pinLocation = CLLocation(latitude: pin.coordinate.latitude, longitude: pin.coordinate.longitude)
             let distance = clLocation.distance(from: pinLocation)
 
-            if distance < DETERMINE_AREA {
+            if distance < MainViewModel.DETERMINE_AREA {
                onDeterminedArea(pin: pin)
             }
         }

--- a/App/LocationNote/LocationNote/Shared/AppDelegate.swift
+++ b/App/LocationNote/LocationNote/Shared/AppDelegate.swift
@@ -27,13 +27,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         locationManager = CLLocationManager()
         locationManager.allowsBackgroundLocationUpdates = true
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
-        locationManager.distanceFilter = 10
+        locationManager.distanceFilter = 25
         locationManager.delegate = self
-
-        // 位置情報起因で起動した場合のみ処理する
-        if launchOptions?[.location] != nil {
-            locationManager.startMonitoringSignificantLocationChanges()
-        }
 
         return true
     }
@@ -98,20 +93,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
-        // バックグラウンドに入る前
-        locationManager.startMonitoringSignificantLocationChanges()
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
-        // フォアグランド
-        locationManager.startMonitoringSignificantLocationChanges()
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
         // アプリが終了（キル）される前
+        locationManager.stopUpdatingLocation()
         locationManager.startMonitoringSignificantLocationChanges()
     }
 
+    private func createUserNotificationRequest(memo: Memo) {
+       let notificationContent = UNMutableNotificationContent()
+       notificationContent.title = memo.title
+        notificationContent.body = String(describing: "\(memo.detail) \(memo.tag)")
+       notificationContent.sound = UNNotificationSound.default
+
+       let request = UNNotificationRequest(identifier: "LocationNote", content: notificationContent, trigger: nil)
+
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+   }
 }
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
@@ -123,8 +125,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 extension AppDelegate: CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        // TODO 処理
-        print(locations.last!)
+        // TODO ピンの情報と比較　通知
+//        createUserNotificationRequest(memo: Memo(title: "テストテスト", detail: "aaa", tag: "", latitude: 0.0, longitude: 0.0))
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
@@ -141,6 +143,7 @@ extension AppDelegate: CLLocationManagerDelegate {
         } else if status == .authorizedAlways {
             print("常に許可している")
             locationManager.startUpdatingLocation()
+            locationManager.startMonitoringSignificantLocationChanges()
         }
     }
 }

--- a/App/LocationNote/LocationNote/Shared/AppDelegate.swift
+++ b/App/LocationNote/LocationNote/Shared/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         locationManager = CLLocationManager()
         locationManager.allowsBackgroundLocationUpdates = true
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
-        locationManager.distanceFilter = 25
+        locationManager.distanceFilter = 100
         locationManager.delegate = self
 
         return true

--- a/App/LocationNote/LocationNote/Shared/SceneDelegate.swift
+++ b/App/LocationNote/LocationNote/Shared/SceneDelegate.swift
@@ -6,10 +6,12 @@
 //
 
 import UIKit
+import CoreLocation
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     private var rootViewController = RootViewController()
+    var locationManager: CLLocationManager!
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
 
@@ -20,10 +22,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
+
+        locationManager = CLLocationManager()
+        locationManager.allowsBackgroundLocationUpdates = true
+        locationManager.desiredAccuracy = kCLLocationAccuracyBest
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
-
+        // アプリが終了（キル）される前
+        locationManager.stopUpdatingLocation()
+        locationManager.startMonitoringSignificantLocationChanges()
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
@@ -39,5 +47,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidEnterBackground(_ scene: UIScene) {
 
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+
+        // バックグラウンドに入る前
+        locationManager.stopUpdatingLocation()
+        locationManager.startMonitoringSignificantLocationChanges()
     }
 }


### PR DESCRIPTION
## 関連
- closes #51 , #62 

## 概要
バックグラウンド時にも通知が出せるよう実装
- AppDelegate,SceneDelegateにバクグラウンド、タスクキル時の処理を追加
- タスクキルされた状態でも位置の判定と通知を出す処理が行えるよう実装

## スクリーンショット
<img width=150 src="https://user-images.githubusercontent.com/17796784/204121632-5ba33e3f-d658-4c14-90a8-c6bca235d0b8.png"/>


## 動作確認

- [x] ビルドができること
- [x] プロセスがない状態でも位置情報の取得ができていること
- [x] プロセスがない状態でもピンに近づいた際に通知が出ること

