### PR TITLE
不要なレイアウトや処理を削除

### DIFF
--- a/App/LocationNote/LocationNote/Model/Data/Memo.swift
+++ b/App/LocationNote/LocationNote/Model/Data/Memo.swift
@@ -11,11 +11,8 @@ import CoreLocation
 // データ保存用のメモクラス
 // CLLocationCoordinate2DがCodableに対応していないためlat/lonをDoubleで保持
 struct Memo: Codable {
-    static let SEPARATOR = "\n #"
-
     var title: String
     var detail: String
-    var tag: String
     let latitude: Double
     let longitude: Double
     var lastNoticeDate: Date = Date()

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.storyboard
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.storyboard
@@ -64,19 +64,19 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bhf-m6-gtc" userLabel="memo">
-                                        <rect key="frame" x="0.0" y="116" width="342" height="361"/>
+                                        <rect key="frame" x="0.0" y="116" width="342" height="417"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="KYC-PH-oid">
-                                                <rect key="frame" x="0.0" y="0.0" width="342" height="361"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="342" height="417"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="詳細" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4WK-uw-U73">
-                                                        <rect key="frame" x="0.0" y="0.0" width="342" height="17"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="342" height="0.0"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" name="black2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="BTp-4k-IxZ">
-                                                        <rect key="frame" x="0.0" y="25" width="342" height="336"/>
+                                                        <rect key="frame" x="0.0" y="8" width="342" height="409"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <color key="textColor" systemColor="labelColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -92,46 +92,11 @@
                                             <constraint firstItem="KYC-PH-oid" firstAttribute="top" secondItem="bhf-m6-gtc" secondAttribute="top" id="xPR-h7-Ku5"/>
                                         </constraints>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bDW-1d-fVC" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="477" width="342" height="24"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="24" id="D1p-aa-KCn"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QKM-lC-S46" userLabel="tag">
-                                        <rect key="frame" x="0.0" y="501" width="342" height="56"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="deK-g1-lAo">
-                                                <rect key="frame" x="0.0" y="0.0" width="342" height="56"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="タグ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UdR-yp-Boq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="342" height="14"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <color key="textColor" name="black2"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="タグを入力('#'で区切ってください)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="T2x-rv-vIm">
-                                                        <rect key="frame" x="0.0" y="22" width="342" height="34"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits"/>
-                                                    </textField>
-                                                </subviews>
-                                            </stackView>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="56" id="47a-Cn-OEo"/>
-                                            <constraint firstItem="deK-g1-lAo" firstAttribute="leading" secondItem="QKM-lC-S46" secondAttribute="leading" id="9G6-Dn-6X3"/>
-                                            <constraint firstAttribute="trailing" secondItem="deK-g1-lAo" secondAttribute="trailing" id="9dm-NO-Jeq"/>
-                                            <constraint firstAttribute="bottom" secondItem="deK-g1-lAo" secondAttribute="bottom" id="ISL-zc-qHE"/>
-                                            <constraint firstItem="deK-g1-lAo" firstAttribute="top" secondItem="QKM-lC-S46" secondAttribute="top" id="LGN-qI-srq"/>
-                                        </constraints>
-                                    </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nVT-AN-0lx" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="557" width="342" height="24"/>
+                                        <rect key="frame" x="0.0" y="533" width="342" height="48"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="24" id="BCR-2c-57a"/>
+                                            <constraint firstAttribute="height" constant="48" id="BCR-2c-57a"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="olf-M8-ds0" userLabel="lat_lon">
@@ -211,7 +176,6 @@
                         <outlet property="addButton" destination="pH2-PQ-g1O" id="7b0-Xj-aPA"/>
                         <outlet property="detailTextView" destination="BTp-4k-IxZ" id="z2D-tk-0Sn"/>
                         <outlet property="locationLabel" destination="wni-WF-FCk" id="Csc-Za-42R"/>
-                        <outlet property="tagTextField" destination="T2x-rv-vIm" id="Pg5-Nd-EOf"/>
                         <outlet property="titleTextField" destination="hMO-9U-LmX" id="VlK-hL-2sp"/>
                     </connections>
                 </viewController>

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.swift
@@ -14,7 +14,6 @@ class AddMemoViewController: BaseViewController {
 
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var detailTextView: UITextView!
-    @IBOutlet weak var tagTextField: UITextField!
     @IBOutlet weak var locationLabel: UILabel!
     @IBOutlet weak var addButton: PrimaryButton!
 
@@ -77,10 +76,6 @@ extension AddMemoViewController {
         detailTextView.layer.borderWidth = 1
         detailTextView.layer.borderColor = R.color.white2()?.cgColor
         detailTextView.layer.cornerRadius = 4
-
-        tagTextField.layer.borderColor = R.color.white2()?.cgColor
-        tagTextField.layer.borderWidth = 1
-        tagTextField.layer.cornerRadius = 4
     }
 
     func bind() {
@@ -96,11 +91,6 @@ extension AddMemoViewController {
         detailTextView.rx.text.orEmpty
             .asDriver()
             .drive(addMemoViewModel.detail)
-            .disposed(by: disposeBag)
-
-        tagTextField.rx.text.orEmpty
-            .asDriver()
-            .drive(addMemoViewModel.tag)
             .disposed(by: disposeBag)
 
         addButton.rx.tap

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
@@ -25,11 +25,6 @@ final class AddMemoViewModel {
         _detail.asObserver()
     }
 
-    private let _tag = BehaviorSubject<String>(value: "")
-    var tag: AnyObserver<String> {
-        _tag.asObserver()
-    }
-
     // OutPut
     private let _buttonEnabled = BehaviorRelay<Bool>(value: false)
     var buttonEnabled: Driver<Bool> {
@@ -51,11 +46,11 @@ final class AddMemoViewModel {
 
 extension AddMemoViewModel {
     func onAddButtonTapped() {
-        guard let title = try? _title.value(), let detail = try? _detail.value(), let tag = try? _tag.value() else {
+        guard let title = try? _title.value(), let detail = try? _detail.value() else {
             return
         }
 
-        let memo = Memo.init(title: title, detail: detail, tag: tag, latitude: location.latitude, longitude: location.longitude)
+        let memo = Memo.init(title: title, detail: detail, latitude: location.latitude, longitude: location.longitude)
 
         dataStore.saveMmemo(memo: memo)
     }

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.storyboard
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.storyboard
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,33 +15,33 @@
             <objects>
                 <viewController id="Y6W-OH-hqX" customClass="EditMemoViewController" customModule="LocationNote" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Qdh-A3-MIq">
-                                <rect key="frame" x="24" y="0.0" width="552" height="600"/>
+                                <rect key="frame" x="24" y="59" width="345" height="759"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DM2-Yc-hNL" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="0.0" width="552" height="36"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="345" height="36"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="36" id="whu-HT-h2n"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0zN-9m-94r" userLabel="title">
-                                        <rect key="frame" x="0.0" y="36" width="552" height="56"/>
+                                        <rect key="frame" x="0.0" y="36" width="345" height="56"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="250-Eq-lkL">
-                                                <rect key="frame" x="0.0" y="0.0" width="552" height="56"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="345" height="56"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="タイトル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GwQ-nu-tRL">
-                                                        <rect key="frame" x="0.0" y="0.0" width="552" height="14"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="345" height="14"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" name="black2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="253" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="タイトルを入力" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tkr-kz-7FR">
-                                                        <rect key="frame" x="0.0" y="22" width="552" height="34"/>
+                                                        <rect key="frame" x="0.0" y="22" width="345" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                     </textField>
@@ -55,26 +57,26 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fmn-LE-5tK" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="92" width="552" height="24"/>
+                                        <rect key="frame" x="0.0" y="92" width="345" height="24"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="24" id="Ee5-Ni-Ry2"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hla-eQ-YK3" userLabel="memo">
-                                        <rect key="frame" x="0.0" y="116" width="552" height="198"/>
+                                        <rect key="frame" x="0.0" y="116" width="345" height="413"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="a8i-nI-vDS">
-                                                <rect key="frame" x="0.0" y="0.0" width="552" height="198"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="345" height="413"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="詳細" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbq-PC-o5e">
-                                                        <rect key="frame" x="0.0" y="0.0" width="552" height="0.0"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="345" height="0.0"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" name="black2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="l7x-9B-Cz5">
-                                                        <rect key="frame" x="0.0" y="8" width="552" height="190"/>
+                                                        <rect key="frame" x="0.0" y="8" width="345" height="405"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <color key="textColor" systemColor="labelColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -91,61 +93,26 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E8j-wY-rvo" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="314" width="552" height="24"/>
+                                        <rect key="frame" x="0.0" y="529" width="345" height="48"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="24" id="qdl-CM-qKY"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="teN-ZP-N0X" userLabel="tag">
-                                        <rect key="frame" x="0.0" y="338" width="552" height="56"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="39e-iV-Fzw">
-                                                <rect key="frame" x="0.0" y="0.0" width="552" height="56"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="タグ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oVB-rI-eRg">
-                                                        <rect key="frame" x="0.0" y="0.0" width="552" height="14"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <color key="textColor" name="black2"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="タグを入力('#'で区切ってください)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="03i-ev-hZp">
-                                                        <rect key="frame" x="0.0" y="22" width="552" height="34"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits"/>
-                                                    </textField>
-                                                </subviews>
-                                            </stackView>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="39e-iV-Fzw" secondAttribute="bottom" id="2PV-G0-g7L"/>
-                                            <constraint firstAttribute="height" constant="56" id="5Nr-7C-qoI"/>
-                                            <constraint firstAttribute="trailing" secondItem="39e-iV-Fzw" secondAttribute="trailing" id="KqE-1a-mrA"/>
-                                            <constraint firstItem="39e-iV-Fzw" firstAttribute="top" secondItem="teN-ZP-N0X" secondAttribute="top" id="oZX-bm-7kv"/>
-                                            <constraint firstItem="39e-iV-Fzw" firstAttribute="leading" secondItem="teN-ZP-N0X" secondAttribute="leading" id="qXF-Gq-6QZ"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ane-8m-a5V" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="394" width="552" height="24"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="24" id="ZGc-Yi-Ehd"/>
+                                            <constraint firstAttribute="height" constant="48" id="qdl-CM-qKY"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rgV-3Q-RCi" userLabel="lat_lon">
-                                        <rect key="frame" x="0.0" y="418" width="552" height="60"/>
+                                        <rect key="frame" x="0.0" y="577" width="345" height="60"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="83s-5u-diN">
-                                                <rect key="frame" x="0.0" y="0.0" width="552" height="60"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="345" height="60"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="緯度経度" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vye-Na-tVs">
-                                                        <rect key="frame" x="0.0" y="0.0" width="552" height="15.666666666666666"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="345" height="15.666666666666666"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <color key="textColor" name="black2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="753" text="35.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lGx-xt-NS6">
-                                                        <rect key="frame" x="0.0" y="23.666666666666689" width="552" height="36.333333333333343"/>
+                                                        <rect key="frame" x="0.0" y="23.666666666666632" width="345" height="36.333333333333343"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -162,17 +129,17 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZJ1-YM-K0m" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="478" width="552" height="50"/>
+                                        <rect key="frame" x="0.0" y="637" width="345" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="50" id="9pL-z2-Zeb"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oFa-8t-7SN" userLabel="button">
-                                        <rect key="frame" x="0.0" y="528" width="552" height="48"/>
+                                        <rect key="frame" x="0.0" y="687" width="345" height="48"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eFt-XR-Csg" customClass="PrimaryButton" customModule="LocationNote" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="552" height="48"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="345" height="48"/>
                                                 <color key="tintColor" name="white1"/>
                                                 <state key="normal" title="Button"/>
                                                 <buttonConfiguration key="configuration" style="plain" title="変更"/>
@@ -187,7 +154,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AqX-rL-rz2" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="576" width="552" height="24"/>
+                                        <rect key="frame" x="0.0" y="735" width="345" height="24"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="24" id="yhW-Es-lgw"/>
@@ -209,7 +176,6 @@
                         <outlet property="detailTextView" destination="l7x-9B-Cz5" id="A7p-kd-zuQ"/>
                         <outlet property="editButton" destination="eFt-XR-Csg" id="enG-GM-JTg"/>
                         <outlet property="locationLabel" destination="lGx-xt-NS6" id="bNi-Qp-xoj"/>
-                        <outlet property="tagTextField" destination="03i-ev-hZp" id="Lf4-6O-Qex"/>
                         <outlet property="titleTextField" destination="tkr-kz-7FR" id="dYc-EZ-IbY"/>
                     </connections>
                 </viewController>

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
@@ -14,7 +14,6 @@ import RxCocoa
 class EditMemoViewController: BaseViewController {
     @IBOutlet weak var titleTextField: UITextField!
     @IBOutlet weak var detailTextView: UITextView!
-    @IBOutlet weak var tagTextField: UITextField!
     @IBOutlet weak var locationLabel: UILabel!
     @IBOutlet weak var editButton: PrimaryButton!
 
@@ -69,11 +68,6 @@ extension EditMemoViewController {
         detailTextView.layer.borderColor = R.color.white2()?.cgColor
         detailTextView.layer.cornerRadius = 4
         detailTextView.text = memo?.detail
-
-        tagTextField.layer.borderColor = R.color.white2()?.cgColor
-        tagTextField.layer.borderWidth = 1
-        tagTextField.layer.cornerRadius = 4
-        tagTextField.text = memo?.tag
     }
 }
 
@@ -114,11 +108,6 @@ extension EditMemoViewController {
         detailTextView.rx.text.orEmpty
             .asDriver()
             .drive(viewModel.detail)
-            .disposed(by: disposeBag)
-
-        tagTextField.rx.text.orEmpty
-            .asDriver()
-            .drive(viewModel.tag)
             .disposed(by: disposeBag)
 
         editButton.rx.tap

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
@@ -23,11 +23,6 @@ final class EditMemoViewModel {
         _detail.asObserver()
     }
 
-    private let _tag = BehaviorSubject<String>(value: "")
-    var tag: AnyObserver<String> {
-        _tag.asObserver()
-    }
-
     // OutPut
     private let _buttonEnabled = BehaviorRelay<Bool>(value: false)
     var buttonEnabled: Driver<Bool> {
@@ -49,11 +44,11 @@ final class EditMemoViewModel {
 
 extension EditMemoViewModel {
     func createMemo() -> Memo? {
-        guard let title = try? _title.value(), let detail = try? _detail.value(), let tag = try? _tag.value() else {
+        guard let title = try? _title.value(), let detail = try? _detail.value() else {
             return nil
         }
 
-        return Memo.init(title: title, detail: detail, tag: tag, latitude: memo.latitude, longitude: memo.longitude)
+        return Memo.init(title: title, detail: detail, latitude: memo.latitude, longitude: memo.longitude)
     }
 
     func onDeleteButtonTapped() {

--- a/App/LocationNote/LocationNote/Screen/Main/Base.lproj/Main.storyboard
+++ b/App/LocationNote/LocationNote/Screen/Main/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Map view configurations" minToolsVersion="14.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
@@ -23,13 +23,6 @@
                                 <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                                 <standardMapConfiguration key="preferredConfiguration"/>
                             </mapView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BVP-Hn-ftq" customClass="SearchBar" customModule="LocationNote" customModuleProvider="target">
-                                <rect key="frame" x="24" y="47" width="342" height="44"/>
-                                <color key="backgroundColor" name="white1"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="3sX-mw-5Te"/>
-                                </constraints>
-                            </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OLw-NZ-Eik">
                                 <rect key="frame" x="311" y="707" width="55" height="55"/>
                                 <constraints>
@@ -60,7 +53,6 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" name="white1"/>
                         <constraints>
-                            <constraint firstItem="BVP-Hn-ftq" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="3gl-hA-V91"/>
                             <constraint firstItem="n5R-c8-iYt" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="68K-3C-8q2"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="rbo-Ct-al8" secondAttribute="trailing" constant="24" id="865-hA-OGi"/>
                             <constraint firstItem="n5R-c8-iYt" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="AMH-70-Egt"/>
@@ -70,16 +62,13 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="OLw-NZ-Eik" secondAttribute="bottom" constant="48" id="Ouu-48-Ue3"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="OLw-NZ-Eik" secondAttribute="trailing" constant="24" id="aGb-EH-Iri"/>
                             <constraint firstAttribute="bottom" secondItem="n5R-c8-iYt" secondAttribute="bottom" id="ejy-g3-pLq"/>
-                            <constraint firstAttribute="trailing" secondItem="BVP-Hn-ftq" secondAttribute="trailing" constant="24" id="phv-2q-6sa"/>
                             <constraint firstAttribute="trailing" secondItem="n5R-c8-iYt" secondAttribute="trailing" id="tkI-lc-Ks1"/>
-                            <constraint firstItem="BVP-Hn-ftq" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="24" id="w9v-sM-ASs"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="addButton" destination="OLw-NZ-Eik" id="0E1-D0-JWW"/>
                         <outlet property="locateButton" destination="rbo-Ct-al8" id="BkW-Q5-3TD"/>
                         <outlet property="mapView" destination="n5R-c8-iYt" id="KLe-L9-DVP"/>
-                        <outlet property="searchBar" destination="BVP-Hn-ftq" id="3nd-UK-SGT"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -12,7 +12,6 @@ import MapKit
 class MainViewController: BaseViewController {
 
     @IBOutlet weak var mapView: MKMapView!
-    @IBOutlet weak var searchBar: SearchBar!
     @IBOutlet weak var locateButton: UIButton!
     @IBOutlet weak var addButton: UIButton!
 

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
@@ -63,12 +63,8 @@ final class MainViewModel {
        savedMemoList.forEach { memo in
            let annotation = MKPointAnnotation()
            annotation.coordinate = CLLocationCoordinate2DMake(memo.latitude, memo.longitude)
-
            annotation.title = memo.title
-
-           // タグがある場合はセパレータをつけて合体させる
-           annotation.subtitle = memo.detail  + Memo.SEPARATOR + memo.tag
-
+           annotation.subtitle = memo.detail
            annotationArray.append(annotation)
        }
 
@@ -79,7 +75,7 @@ final class MainViewModel {
         var memo: Memo
         let detailTagArray = annotation.subtitle??.components(separatedBy: Memo.SEPARATOR)
 
-        memo = Memo(title: (annotation.title ?? "") ?? "", detail: detailTagArray?[0] ?? "", tag: detailTagArray?[1] ?? "", latitude: annotation.coordinate.latitude, longitude: annotation.coordinate.longitude)
+        memo = Memo(title: (annotation.title ?? "") ?? "", detail: detailTagArray?[0] ?? "", latitude: annotation.coordinate.latitude, longitude: annotation.coordinate.longitude)
 
         _editMemoDriver.accept(memo)
     }
@@ -117,7 +113,7 @@ final class MainViewModel {
      private func createUserNotificationRequest(memo: Memo) {
         let notificationContent = UNMutableNotificationContent()
         notificationContent.title = memo.title
-         notificationContent.body = String(describing: "\(memo.detail) \(memo.tag)")
+         notificationContent.body = memo.detail
         notificationContent.sound = UNNotificationSound.default
 
         let request = UNNotificationRequest(identifier: "LocationNote", content: notificationContent, trigger: nil)

--- a/App/LocationNote/LocationNote/Shared/AppDelegate.swift
+++ b/App/LocationNote/LocationNote/Shared/AppDelegate.swift
@@ -185,7 +185,7 @@ extension AppDelegate {
     private func createUserNotificationRequest(memo: Memo) {
        let notificationContent = UNMutableNotificationContent()
        notificationContent.title = memo.title
-        notificationContent.body = String(describing: "\(memo.detail) \(memo.tag)")
+        notificationContent.body = memo.detail
        notificationContent.sound = UNNotificationSound.default
 
        let request = UNNotificationRequest(identifier: "LocationNote", content: notificationContent, trigger: nil)

--- a/App/LocationNote/LocationNote/Util/DataStore.swift
+++ b/App/LocationNote/LocationNote/Util/DataStore.swift
@@ -39,7 +39,6 @@ struct DataStore {
 
         data?[index].title = memo.title
         data?[index].detail = memo.detail
-        data?[index].tag = memo.tag
         data?[index].lastNoticeDate = memo.lastNoticeDate
 
         saveMmemoList(memoList: data ?? [])


### PR DESCRIPTION
## 関連
- close #69 

## 概要
- マップ画面
   - 検索欄
      - 処理内容・実装時期未定のため
- メモ追加/編集画面
   - tag欄
      - 使途不明のため
         - 詳細欄に入れればいいのでは
- tagの入力をなくしたことによりMemoのモデルクラスからtagを削除
   - 関連箇所を削除

## スクリーンショット
|対応前|対応後|
|---|---|
|<img width=150 src="https://user-images.githubusercontent.com/17796784/204134106-919ce05f-2868-4520-a67c-ebf9a0f511de.png"/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/204134047-fe4bcd46-8914-46e0-9d92-d8989894d5df.png"/>|
|<img width=150 src="https://user-images.githubusercontent.com/17796784/204134109-7e396cff-54e8-4068-971c-5ede36a367bf.png"/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/204134054-7d17b3b1-09f4-4388-b496-ee5e1b1590aa.png"/>|
|<img width=150 src="https://user-images.githubusercontent.com/17796784/204134111-cd096395-2ed3-4829-8aa9-8d77bda69994.png"/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/204134060-cbf30feb-59bc-44a0-8cab-fde37f37f72e.png"/>|




## 動作確認


- [x] ビルドができること
- [x] 各画面のレイアウトが崩れていないこと

