### PR TITLE
メモごとの通知のオンオフ設定を追加

### DIFF
--- a/App/LocationNote/LocationNote/Base.lproj/LaunchScreen.storyboard
+++ b/App/LocationNote/LocationNote/Base.lproj/LaunchScreen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,18 +17,25 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="LocalPin" translatesAutoresizingMaskIntoConstraints="NO" id="ks8-F0-C1p">
-                                <rect key="frame" x="75" y="358" width="240" height="128"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LocalPin" translatesAutoresizingMaskIntoConstraints="NO" id="ks8-F0-C1p">
+                                <rect key="frame" x="135" y="362" width="120" height="120"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="120" id="ExQ-8P-tWe"/>
+                                    <constraint firstAttribute="height" constant="120" id="hLh-wX-pLO"/>
+                                </constraints>
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ks8-F0-C1p" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="4Ry-t5-fRA"/>
+                            <constraint firstItem="ks8-F0-C1p" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="POC-qA-cxa"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="53" y="375"/>
+            <point key="canvasLocation" x="52.307692307692307" y="374.64454976303318"/>
         </scene>
     </scenes>
     <resources>

--- a/App/LocationNote/LocationNote/Model/Data/Memo.swift
+++ b/App/LocationNote/LocationNote/Model/Data/Memo.swift
@@ -15,5 +15,6 @@ struct Memo: Codable {
     var detail: String
     let latitude: Double
     let longitude: Double
+    let isSendNotice: Bool
     var lastNoticeDate: Date = Date()
 }

--- a/App/LocationNote/LocationNote/Model/Data/Memo.swift
+++ b/App/LocationNote/LocationNote/Model/Data/Memo.swift
@@ -15,6 +15,6 @@ struct Memo: Codable {
     var detail: String
     let latitude: Double
     let longitude: Double
-    let isSendNotice: Bool
+    var isSendNotice: Bool
     var lastNoticeDate: Date = Date()
 }

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.storyboard
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.storyboard
@@ -64,19 +64,19 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bhf-m6-gtc" userLabel="memo">
-                                        <rect key="frame" x="0.0" y="116" width="342" height="417"/>
+                                        <rect key="frame" x="0.0" y="116" width="342" height="407"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="KYC-PH-oid">
-                                                <rect key="frame" x="0.0" y="0.0" width="342" height="417"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="342" height="407"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="詳細" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4WK-uw-U73">
-                                                        <rect key="frame" x="0.0" y="0.0" width="342" height="0.0"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="342" height="17"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" name="black2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="BTp-4k-IxZ">
-                                                        <rect key="frame" x="0.0" y="8" width="342" height="409"/>
+                                                        <rect key="frame" x="0.0" y="25" width="342" height="382"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <color key="textColor" systemColor="labelColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -93,14 +93,48 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nVT-AN-0lx" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="533" width="342" height="48"/>
+                                        <rect key="frame" x="0.0" y="523" width="342" height="24"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="48" id="BCR-2c-57a"/>
+                                            <constraint firstAttribute="height" constant="24" id="BCR-2c-57a"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6oC-j6-uiL" userLabel="notice_toggle">
+                                        <rect key="frame" x="0.0" y="547" width="342" height="32"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EZA-F2-Z6J">
+                                                <rect key="frame" x="0.0" y="0.0" width="342" height="32"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="通知" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HAo-CD-2rE">
+                                                        <rect key="frame" x="0.0" y="0.0" width="293" height="32"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <color key="textColor" name="black2"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vb1-Ly-TX9">
+                                                        <rect key="frame" x="293" y="0.0" width="51" height="32"/>
+                                                    </switch>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="EZA-F2-Z6J" firstAttribute="leading" secondItem="6oC-j6-uiL" secondAttribute="leading" id="bi5-eB-lSU"/>
+                                            <constraint firstItem="EZA-F2-Z6J" firstAttribute="top" secondItem="6oC-j6-uiL" secondAttribute="top" id="dmw-Fi-ghn"/>
+                                            <constraint firstAttribute="bottom" secondItem="EZA-F2-Z6J" secondAttribute="bottom" id="ft6-oD-DKX"/>
+                                            <constraint firstAttribute="height" constant="32" id="qjf-xI-ra3"/>
+                                            <constraint firstAttribute="trailing" secondItem="EZA-F2-Z6J" secondAttribute="trailing" id="tge-pE-IIE"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8xE-oQ-X4r" userLabel="margin">
+                                        <rect key="frame" x="0.0" y="579" width="342" height="24"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="24" id="rvt-Ps-w9I"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="olf-M8-ds0" userLabel="lat_lon">
-                                        <rect key="frame" x="0.0" y="581" width="342" height="60"/>
+                                        <rect key="frame" x="0.0" y="603" width="342" height="60"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8z2-s6-EkU">
                                                 <rect key="frame" x="0.0" y="0.0" width="342" height="60"/>
@@ -129,10 +163,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3nf-fU-rct" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="641" width="342" height="50"/>
+                                        <rect key="frame" x="0.0" y="663" width="342" height="28"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="50" id="mjh-F8-mVF"/>
+                                            <constraint firstAttribute="height" constant="28" id="mjh-F8-mVF"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pod-dx-7Dh" userLabel="button">
@@ -176,12 +210,13 @@
                         <outlet property="addButton" destination="pH2-PQ-g1O" id="7b0-Xj-aPA"/>
                         <outlet property="detailTextView" destination="BTp-4k-IxZ" id="z2D-tk-0Sn"/>
                         <outlet property="locationLabel" destination="wni-WF-FCk" id="Csc-Za-42R"/>
+                        <outlet property="noticeSwitch" destination="vb1-Ly-TX9" id="ZBH-eA-O3K"/>
                         <outlet property="titleTextField" destination="hMO-9U-LmX" id="VlK-hL-2sp"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="58" y="-2"/>
+            <point key="canvasLocation" x="56.92307692307692" y="-2.1327014218009479"/>
         </scene>
     </scenes>
     <resources>

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.swift
@@ -13,10 +13,11 @@ import GoogleMobileAds
 
 class AddMemoViewController: BaseViewController {
 
-    @IBOutlet weak var titleTextField: UITextField!
-    @IBOutlet weak var detailTextView: UITextView!
-    @IBOutlet weak var locationLabel: UILabel!
-    @IBOutlet weak var addButton: PrimaryButton!
+    @IBOutlet private weak var titleTextField: UITextField!
+    @IBOutlet private weak var detailTextView: UITextView!
+    @IBOutlet private weak var locationLabel: UILabel!
+    @IBOutlet private weak var addButton: PrimaryButton!
+    @IBOutlet private weak var noticeSwitch: UISwitch!
 
     private var closeButtonItem: UIBarButtonItem!
     private var addMemoViewModel: AddMemoViewModel?
@@ -108,13 +109,18 @@ extension AddMemoViewController {
             .drive(addMemoViewModel.detail)
             .disposed(by: disposeBag)
 
+        noticeSwitch.rx.isOn
+            .asDriver()
+            .drive(addMemoViewModel.isSendNotice)
+            .disposed(by: disposeBag)
+
         addButton.rx.tap
             .asDriver()
             .drive(onNext: {
                 if let interstitial = self.interstitial {
                     // 広告表示
                     interstitial.present(fromRootViewController: self)
-                }else{
+                } else {
                     // 広告が読み込まれなければ通常の動作に
                     self.addMemoViewModel?.onAddButtonTapped()
                     self.dismiss(animated: true)

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
@@ -25,6 +25,11 @@ final class AddMemoViewModel {
         _detail.asObserver()
     }
 
+    private let _isSendNotice = BehaviorSubject<Bool>(value: true)
+    var isSendNotice: AnyObserver<Bool> {
+        _isSendNotice.asObserver()
+    }
+
     private var _isAdLoaded = false
 
     // OutPut
@@ -48,11 +53,11 @@ final class AddMemoViewModel {
 
 extension AddMemoViewModel {
     func onAddButtonTapped() {
-        guard let title = try? _title.value(), let detail = try? _detail.value() else {
+        guard let title = try? _title.value(), let detail = try? _detail.value(), let isSendNotice = try? _isSendNotice.value() else {
             return
         }
 
-        let memo = Memo.init(title: title, detail: detail, latitude: location.latitude, longitude: location.longitude)
+        let memo = Memo.init(title: title, detail: detail, latitude: location.latitude, longitude: location.longitude, isSendNotice: isSendNotice)
 
         dataStore.saveMmemo(memo: memo)
     }

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.storyboard
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.storyboard
@@ -64,19 +64,19 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hla-eQ-YK3" userLabel="memo">
-                                        <rect key="frame" x="0.0" y="116" width="345" height="413"/>
+                                        <rect key="frame" x="0.0" y="116" width="345" height="403"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="a8i-nI-vDS">
-                                                <rect key="frame" x="0.0" y="0.0" width="345" height="413"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="345" height="403"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="詳細" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbq-PC-o5e">
-                                                        <rect key="frame" x="0.0" y="0.0" width="345" height="0.0"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="345" height="17"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" name="black2"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="l7x-9B-Cz5">
-                                                        <rect key="frame" x="0.0" y="8" width="345" height="405"/>
+                                                        <rect key="frame" x="0.0" y="25" width="345" height="378"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <color key="textColor" systemColor="labelColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -93,14 +93,49 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E8j-wY-rvo" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="529" width="345" height="48"/>
+                                        <rect key="frame" x="0.0" y="519" width="345" height="24"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="48" id="qdl-CM-qKY"/>
+                                            <constraint firstAttribute="height" constant="24" id="qdl-CM-qKY"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rt5-Dg-nUD" userLabel="notice_toggle">
+                                        <rect key="frame" x="0.0" y="543" width="345" height="32"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kSp-nF-2JE">
+                                                <rect key="frame" x="0.0" y="0.0" width="345" height="32"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="通知" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A1N-bK-aik">
+                                                        <rect key="frame" x="0.0" y="0.0" width="296" height="32"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <color key="textColor" name="black2"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="v3V-4X-acq">
+                                                        <rect key="frame" x="296" y="0.0" width="51" height="32"/>
+                                                    </switch>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="kSp-nF-2JE" firstAttribute="top" secondItem="Rt5-Dg-nUD" secondAttribute="top" id="Bi6-tF-EWI"/>
+                                            <constraint firstItem="kSp-nF-2JE" firstAttribute="leading" secondItem="Rt5-Dg-nUD" secondAttribute="leading" id="Idn-FU-jNV"/>
+                                            <constraint firstAttribute="width" constant="32" id="UEH-Th-Hfz"/>
+                                            <constraint firstAttribute="height" constant="32" id="esl-xC-Oep"/>
+                                            <constraint firstAttribute="trailing" secondItem="kSp-nF-2JE" secondAttribute="trailing" id="ig8-us-5jE"/>
+                                            <constraint firstAttribute="bottom" secondItem="kSp-nF-2JE" secondAttribute="bottom" id="qc0-go-5gX"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nyn-J0-lzP" userLabel="margin">
+                                        <rect key="frame" x="0.0" y="575" width="345" height="24"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="24" id="STb-zV-p0y"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rgV-3Q-RCi" userLabel="lat_lon">
-                                        <rect key="frame" x="0.0" y="577" width="345" height="60"/>
+                                        <rect key="frame" x="0.0" y="599" width="345" height="60"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="83s-5u-diN">
                                                 <rect key="frame" x="0.0" y="0.0" width="345" height="60"/>
@@ -129,10 +164,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZJ1-YM-K0m" userLabel="margin">
-                                        <rect key="frame" x="0.0" y="637" width="345" height="50"/>
+                                        <rect key="frame" x="0.0" y="659" width="345" height="28"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="50" id="9pL-z2-Zeb"/>
+                                            <constraint firstAttribute="height" constant="28" id="9pL-z2-Zeb"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oFa-8t-7SN" userLabel="button">
@@ -176,6 +211,7 @@
                         <outlet property="detailTextView" destination="l7x-9B-Cz5" id="A7p-kd-zuQ"/>
                         <outlet property="editButton" destination="eFt-XR-Csg" id="enG-GM-JTg"/>
                         <outlet property="locationLabel" destination="lGx-xt-NS6" id="bNi-Qp-xoj"/>
+                        <outlet property="noticeSwitch" destination="v3V-4X-acq" id="m2g-Aa-Tpq"/>
                         <outlet property="titleTextField" destination="tkr-kz-7FR" id="dYc-EZ-IbY"/>
                     </connections>
                 </viewController>

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.storyboard
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.storyboard
@@ -121,7 +121,6 @@
                                         <constraints>
                                             <constraint firstItem="kSp-nF-2JE" firstAttribute="top" secondItem="Rt5-Dg-nUD" secondAttribute="top" id="Bi6-tF-EWI"/>
                                             <constraint firstItem="kSp-nF-2JE" firstAttribute="leading" secondItem="Rt5-Dg-nUD" secondAttribute="leading" id="Idn-FU-jNV"/>
-                                            <constraint firstAttribute="width" constant="32" id="UEH-Th-Hfz"/>
                                             <constraint firstAttribute="height" constant="32" id="esl-xC-Oep"/>
                                             <constraint firstAttribute="trailing" secondItem="kSp-nF-2JE" secondAttribute="trailing" id="ig8-us-5jE"/>
                                             <constraint firstAttribute="bottom" secondItem="kSp-nF-2JE" secondAttribute="bottom" id="qc0-go-5gX"/>

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
@@ -13,10 +13,11 @@ import GoogleMobileAds
 
 // MARK: LifeCycle
 class EditMemoViewController: BaseViewController {
-    @IBOutlet weak var titleTextField: UITextField!
-    @IBOutlet weak var detailTextView: UITextView!
-    @IBOutlet weak var locationLabel: UILabel!
-    @IBOutlet weak var editButton: PrimaryButton!
+    @IBOutlet private weak var titleTextField: UITextField!
+    @IBOutlet private weak var detailTextView: UITextView!
+    @IBOutlet private weak var locationLabel: UILabel!
+    @IBOutlet private weak var editButton: PrimaryButton!
+    @IBOutlet private weak var noticeSwitch: UISwitch!
     private var interstitial: GADInterstitialAd?
 
     private var memo: Memo?
@@ -84,6 +85,8 @@ extension EditMemoViewController {
         detailTextView.layer.borderColor = R.color.white2()?.cgColor
         detailTextView.layer.cornerRadius = 4
         detailTextView.text = memo?.detail
+
+        noticeSwitch.isSelected = memo?.isSendNotice ?? true
     }
 }
 
@@ -126,13 +129,18 @@ extension EditMemoViewController {
             .drive(viewModel.detail)
             .disposed(by: disposeBag)
 
+        noticeSwitch.rx.isOn
+            .asDriver()
+            .drive(viewModel.isSendNotice)
+            .disposed(by: disposeBag)
+
         editButton.rx.tap
             .asDriver()
             .drive(onNext: {
                 if let interstitial = self.interstitial {
                     // 広告表示
                     interstitial.present(fromRootViewController: self)
-                }else{
+                } else {
                     // 広告が読み込まれなければ通常の動作に
                     self.viewModel?.onEditButtonTapped()
                     self.dismiss(animated: true)

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
@@ -43,7 +43,6 @@ class EditMemoViewController: BaseViewController {
         let adUnitId = Bundle.main.infoDictionary?["AdUnitId"]! as! String
         GADInterstitialAd.load(withAdUnitID: adUnitId, request: request,
             completionHandler: { [self] ad, error in
-            viewModel?.onAdLoadEnd()
 
             if let error = error {
                 print("Failed to load interstitial ad with error: \(error.localizedDescription)")
@@ -86,7 +85,7 @@ extension EditMemoViewController {
         detailTextView.layer.cornerRadius = 4
         detailTextView.text = memo?.detail
 
-        noticeSwitch.isSelected = memo?.isSendNotice ?? true
+        noticeSwitch.isOn = memo?.isSendNotice ?? true
     }
 }
 
@@ -129,7 +128,7 @@ extension EditMemoViewController {
             .drive(viewModel.detail)
             .disposed(by: disposeBag)
 
-        noticeSwitch.rx.isOn
+        noticeSwitch.rx.value
             .asDriver()
             .drive(viewModel.isSendNotice)
             .disposed(by: disposeBag)

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
@@ -28,11 +28,6 @@ final class EditMemoViewModel {
         _isSendNotice.asObserver()
     }
 
-    private var _isAdLoaded = BehaviorSubject<Bool>(value: false)
-    var isAdLoaded: AnyObserver<Bool> {
-        _isAdLoaded.asObserver()
-    }
-
     // OutPut
     private let _buttonEnabled = BehaviorRelay<Bool>(value: false)
     var buttonEnabled: Driver<Bool> {
@@ -43,12 +38,10 @@ final class EditMemoViewModel {
     private let dataStore = DataStore()
 
     init(memo: Memo) {
-        var isAdLoaded = try? _isAdLoaded.value()
-
         self.memo = memo
 
         _title.asObserver()
-            .map({!$0.isEmpty && isAdLoaded ?? false})
+            .map({!$0.isEmpty})
             .bind(to: _buttonEnabled)
             .disposed(by: disposeBag)
     }
@@ -75,9 +68,5 @@ extension EditMemoViewModel {
             return
         }
         dataStore.editMemo(memo: memo)
-    }
-
-    func onAdLoadEnd() {
-        self.isAdLoaded.onNext(true)
     }
 }

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
@@ -23,6 +23,16 @@ final class EditMemoViewModel {
         _detail.asObserver()
     }
 
+    private let _isSendNotice = BehaviorSubject<Bool>(value: true)
+    var isSendNotice: AnyObserver<Bool> {
+        _isSendNotice.asObserver()
+    }
+
+    private var _isAdLoaded = BehaviorSubject<Bool>(value: false)
+    var isAdLoaded: AnyObserver<Bool> {
+        _isAdLoaded.asObserver()
+    }
+
     // OutPut
     private let _buttonEnabled = BehaviorRelay<Bool>(value: false)
     var buttonEnabled: Driver<Bool> {
@@ -32,13 +42,13 @@ final class EditMemoViewModel {
     private let disposeBag = DisposeBag()
     private let dataStore = DataStore()
 
-    private var _isAdLoaded = false
-
     init(memo: Memo) {
+        var isAdLoaded = try? _isAdLoaded.value()
+
         self.memo = memo
 
         _title.asObserver()
-            .map({!$0.isEmpty && self._isAdLoaded})
+            .map({!$0.isEmpty && isAdLoaded ?? false})
             .bind(to: _buttonEnabled)
             .disposed(by: disposeBag)
     }
@@ -46,11 +56,11 @@ final class EditMemoViewModel {
 
 extension EditMemoViewModel {
     func createMemo() -> Memo? {
-        guard let title = try? _title.value(), let detail = try? _detail.value() else {
+        guard let title = try? _title.value(), let detail = try? _detail.value(), let isSendNotice = try? _isSendNotice.value() else {
             return nil
         }
 
-        return Memo.init(title: title, detail: detail, latitude: memo.latitude, longitude: memo.longitude)
+        return Memo.init(title: title, detail: detail, latitude: memo.latitude, longitude: memo.longitude, isSendNotice: isSendNotice)
     }
 
     func onDeleteButtonTapped() {
@@ -68,6 +78,6 @@ extension EditMemoViewModel {
     }
 
     func onAdLoadEnd() {
-        self._isAdLoaded = true
+        self.isAdLoaded.onNext(true)
     }
 }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
@@ -72,10 +72,9 @@ final class MainViewModel {
     }
 
     func onCalloutAccessoryTapped(annotation: MKAnnotation) {
-        var memo: Memo
-
-        memo = Memo(title: (annotation.title ?? "") ?? "", detail: (annotation.subtitle ?? "") ?? "", latitude: annotation.coordinate.latitude, longitude: annotation.coordinate.longitude)
-
+        guard let  memo = dataStore.loadMemo(from: annotation as! MKPointAnnotation) else {
+            return
+        }
         _editMemoDriver.accept(memo)
     }
 

--- a/App/LocationNote/LocationNote/Shared/AppDelegate.swift
+++ b/App/LocationNote/LocationNote/Shared/AppDelegate.swift
@@ -169,7 +169,7 @@ extension AppDelegate {
                     memo.longitude)
             let distance = clLocation.distance(from: memoLocation)
 
-            if distance < MainViewModel.DETERMINE_AREA {
+            if (distance < MainViewModel.DETERMINE_AREA) && memo.isSendNotice {
                onDeterminedArea(memo: memo)
             }
         }

--- a/App/LocationNote/LocationNote/Util/DataStore.swift
+++ b/App/LocationNote/LocationNote/Util/DataStore.swift
@@ -39,6 +39,7 @@ struct DataStore {
 
         data?[index].title = memo.title
         data?[index].detail = memo.detail
+        data?[index].isSendNotice = memo.isSendNotice
         data?[index].lastNoticeDate = memo.lastNoticeDate
 
         saveMmemoList(memoList: data ?? [])


### PR DESCRIPTION
## 関連
- close #75 

## 概要
- 追加/編集画面に通知を出すかどうかのスイッチを追加
- メモのモデルクラスに通知を出すかどうかのフラグを追加
- 距離判定の際にちいちの設定状態により通知を出す出さない判定を行うよう実装

## スクリーンショット
|対応前|対応後|
|---|---|
|<img width=150 src="https://user-images.githubusercontent.com/17796784/204134060-cbf30feb-59bc-44a0-8cab-fde37f37f72e.png"/>|<img width=150 src="https://user-images.githubusercontent.com/17796784/205425375-ecf765e4-5467-4faf-8324-170a6e53139c.png"/>|


## 動作確認

- [x] ビルドができること
- [x] レイアウトが崩れていないこと
- [x] 編集画面でメモの状態によりスイッチの状態が変わっていること
- [x] 通知設定により通知が来たりこなかったりすること

