### PR TITLE
広告表示にカウントを追加

### DIFF
--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.swift
@@ -117,7 +117,7 @@ extension AddMemoViewController {
         addButton.rx.tap
             .asDriver()
             .drive(onNext: {
-                if let interstitial = self.interstitial {
+                if let interstitial = self.interstitial, addMemoViewModel.isNeedShowAd() {
                     // 広告表示
                     interstitial.present(fromRootViewController: self)
                 } else {

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewController.swift
@@ -41,7 +41,7 @@ class AddMemoViewController: BaseViewController {
         let request = GADRequest()
         let adUnitId = Bundle.main.infoDictionary?["AdUnitId"]! as! String
         GADInterstitialAd.load(withAdUnitID: adUnitId, request: request, completionHandler: { [self] ad, error in
-            addMemoViewModel?.onAdLoadEnd()
+            addMemoViewModel?.isAdAllReady.accept(true)
 
             if let error = error {
                 print("Failed to load interstitial ad with error: \(error.localizedDescription)")
@@ -129,7 +129,7 @@ extension AddMemoViewController {
             .disposed(by: disposeBag)
 
         addMemoViewModel.buttonEnabled
-            .drive(addButton.rx.isEnabled)
+            .bind(to: addButton.rx.isEnabled)
             .disposed(by: disposeBag)
 
     }

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
@@ -30,7 +30,7 @@ final class AddMemoViewModel {
         _isSendNotice.asObserver()
     }
 
-    private var _isAdLoaded = false
+    let isAdAllReady = PublishRelay<Bool>()
 
     private var adCount: Int {
         dataStore.loadCount()
@@ -38,8 +38,10 @@ final class AddMemoViewModel {
 
     // OutPut
     private let _buttonEnabled = BehaviorRelay<Bool>(value: false)
-    var buttonEnabled: Driver<Bool> {
-        _buttonEnabled.asDriver()
+    var buttonEnabled: Observable<Bool> {
+        return Observable.combineLatest(_title, isAdAllReady) { title, isAdAllReady in
+            return !title.isEmpty  && isAdAllReady
+        }
     }
 
     private let disposeBag = DisposeBag()
@@ -47,11 +49,6 @@ final class AddMemoViewModel {
 
     init(location: CLLocationCoordinate2D) {
         self.location = location
-
-        _title.asObserver()
-            .map({!$0.isEmpty && self._isAdLoaded})
-            .bind(to: _buttonEnabled)
-            .disposed(by: disposeBag)
     }
 }
 
@@ -80,9 +77,5 @@ extension AddMemoViewModel {
         let memo = Memo.init(title: title, detail: detail, latitude: location.latitude, longitude: location.longitude, isSendNotice: isSendNotice)
 
         dataStore.saveMmemo(memo: memo)
-    }
-
-    func onAdLoadEnd() {
-        self._isAdLoaded = true
     }
 }

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
@@ -60,7 +60,7 @@ extension AddMemoViewModel {
             return true
         } else {
             let next = adCount + 1
-            if adCount >= 3 {
+            if adCount >= 2 {
                 dataStore.saveCount(count: 0)
             } else {
                 dataStore.saveCount(count: next)

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
@@ -54,7 +54,6 @@ final class AddMemoViewModel {
 
 extension AddMemoViewModel {
     func isNeedShowAd() -> Bool {
-        print(adCount)
         if adCount == 0 {
             dataStore.saveCount(count: adCount + 1)
             return true

--- a/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/AddMemo/AddMemoViewModel.swift
@@ -32,6 +32,10 @@ final class AddMemoViewModel {
 
     private var _isAdLoaded = false
 
+    private var adCount: Int {
+        dataStore.loadCount()
+    }
+
     // OutPut
     private let _buttonEnabled = BehaviorRelay<Bool>(value: false)
     var buttonEnabled: Driver<Bool> {
@@ -52,6 +56,22 @@ final class AddMemoViewModel {
 }
 
 extension AddMemoViewModel {
+    func isNeedShowAd() -> Bool {
+        print(adCount)
+        if adCount == 0 {
+            dataStore.saveCount(count: adCount + 1)
+            return true
+        } else {
+            let next = adCount + 1
+            if adCount >= 3 {
+                dataStore.saveCount(count: 0)
+            } else {
+                dataStore.saveCount(count: next)
+            }
+            return false
+        }
+    }
+
     func onAddButtonTapped() {
         guard let title = try? _title.value(), let detail = try? _detail.value(), let isSendNotice = try? _isSendNotice.value() else {
             return

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
@@ -136,7 +136,7 @@ extension EditMemoViewController {
         editButton.rx.tap
             .asDriver()
             .drive(onNext: {
-                if let interstitial = self.interstitial {
+                if let interstitial = self.interstitial, viewModel.isNeedShowAd() {
                     // 広告表示
                     interstitial.present(fromRootViewController: self)
                 } else {

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewController.swift
@@ -43,6 +43,7 @@ class EditMemoViewController: BaseViewController {
         let adUnitId = Bundle.main.infoDictionary?["AdUnitId"]! as! String
         GADInterstitialAd.load(withAdUnitID: adUnitId, request: request,
             completionHandler: { [self] ad, error in
+            viewModel?.isAdAllReady.accept(true)
 
             if let error = error {
                 print("Failed to load interstitial ad with error: \(error.localizedDescription)")
@@ -148,7 +149,7 @@ extension EditMemoViewController {
             .disposed(by: disposeBag)
 
         viewModel.buttonEnabled
-            .drive(editButton.rx.isEnabled)
+            .bind(to: editButton.rx.isEnabled)
             .disposed(by: disposeBag)
 
     }

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
@@ -31,10 +31,14 @@ final class EditMemoViewModel {
         _isSendNotice.asObserver()
     }
 
+    let isAdAllReady = PublishRelay<Bool>()
+
     // OutPut
     private let _buttonEnabled = BehaviorRelay<Bool>(value: false)
-    var buttonEnabled: Driver<Bool> {
-        _buttonEnabled.asDriver()
+    var buttonEnabled: Observable<Bool> {
+        return Observable.combineLatest(_title, isAdAllReady) { title, isAdAllReady in
+            return !title.isEmpty  && isAdAllReady
+        }
     }
 
     private let disposeBag = DisposeBag()
@@ -42,11 +46,6 @@ final class EditMemoViewModel {
 
     init(memo: Memo) {
         self.memo = memo
-
-        _title.asObserver()
-            .map({!$0.isEmpty})
-            .bind(to: _buttonEnabled)
-            .disposed(by: disposeBag)
     }
 }
 

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
@@ -57,7 +57,7 @@ extension EditMemoViewModel {
             return true
         } else {
             let next = adCount + 1
-            if adCount >= 3 {
+            if adCount >= 2 {
                 dataStore.saveCount(count: 0)
             } else {
                 dataStore.saveCount(count: next)

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
@@ -51,7 +51,6 @@ final class EditMemoViewModel {
 
 extension EditMemoViewModel {
     func isNeedShowAd() -> Bool {
-        print(adCount)
         if adCount == 0 {
             dataStore.saveCount(count: adCount + 1)
             return true

--- a/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/EditMemo/EditMemoViewModel.swift
@@ -11,6 +11,9 @@ import RxCocoa
 
 final class EditMemoViewModel {
     private var memo: Memo
+    private var adCount: Int {
+        dataStore.loadCount()
+    }
 
     // Input
     private let _title = BehaviorSubject<String>(value: "")
@@ -48,6 +51,22 @@ final class EditMemoViewModel {
 }
 
 extension EditMemoViewModel {
+    func isNeedShowAd() -> Bool {
+        print(adCount)
+        if adCount == 0 {
+            dataStore.saveCount(count: adCount + 1)
+            return true
+        } else {
+            let next = adCount + 1
+            if adCount >= 3 {
+                dataStore.saveCount(count: 0)
+            } else {
+                dataStore.saveCount(count: next)
+            }
+            return false
+        }
+    }
+
     func createMemo() -> Memo? {
         guard let title = try? _title.value(), let detail = try? _detail.value(), let isSendNotice = try? _isSendNotice.value() else {
             return nil

--- a/App/LocationNote/LocationNote/Util/DataStore.swift
+++ b/App/LocationNote/LocationNote/Util/DataStore.swift
@@ -10,6 +10,7 @@ import MapKit
 
 enum DataStoreKey: String {
     case MEMO = "Memo"
+    case AD_COUNT = "AdCount"
 }
 
 struct DataStore {
@@ -84,5 +85,16 @@ struct DataStore {
 
     func clearMemo() {
         UserDefaults.standard.set([], forKey: DataStoreKey.MEMO.rawValue)
+    }
+}
+
+// MARK: show AD count
+extension DataStore {
+    func saveCount(count: Int) {
+        UserDefaults.standard.set(count, forKey: DataStoreKey.AD_COUNT.rawValue)
+    }
+
+    func loadCount() -> Int {
+        return UserDefaults.standard.integer(forKey: DataStoreKey.AD_COUNT.rawValue)
     }
 }


### PR DESCRIPTION
## 関連
- close #67 

## 概要
- 広告を表示するのを3回に1回に変更
   - DataStoreに回数を保存・読み込みする処理を追加
- ボタンの活性化条件に広告の読み込み状況を追加

## 動作確認

- [x] ビルドができること
- [x] 3回に１回広告が表示されること
- [x] 広告の読み込みが終わったらボタンが押せるようになること

