### PR TITLE
トラッキングの許可を確認するダイアログ表示を実装

### DIFF
--- a/App/LocationNote/LocationNote/Info.plist
+++ b/App/LocationNote/LocationNote/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>他アプリの情報を活用しよりユーザー様の興味関心にあった広告するために利用することに同意をお願いいたします。</string>
 	<key>BannerAdUnitId</key>
 	<string>$(BannerAdUnitId)</string>
 	<key>AdUnitId</key>

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewController.swift
@@ -37,7 +37,10 @@ class MainViewController: BaseViewController {
         locateButton.addShadow()
         addButton.addShadow()
 
-        checkLocationPermission()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            self.checkLocationPermission()
+        }
+
         bind()
         setMapLongPressRecRecognizer()
         setBannerAdSetting()

--- a/App/LocationNote/LocationNote/Shared/AppDelegate.swift
+++ b/App/LocationNote/LocationNote/Shared/AppDelegate.swift
@@ -10,6 +10,7 @@ import UIKit
 import CoreLocation
 import MapKit
 import GoogleMobileAds
+import AppTrackingTransparency
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -20,8 +21,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
-        if launchOptions?[.location] == nil {
-            GADMobileAds.sharedInstance().start(completionHandler: nil)
+        // トラッキングの許可
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            ATTrackingManager.requestTrackingAuthorization(completionHandler: { _ in
+                // AdMobの初期化
+                GADMobileAds.sharedInstance().start(completionHandler: nil)
+            })
         }
         // 通知許可の取得
         UNUserNotificationCenter.current().requestAuthorization(

--- a/App/LocationNote/LocationNote/Shared/AppDelegate.swift
+++ b/App/LocationNote/LocationNote/Shared/AppDelegate.swift
@@ -27,14 +27,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 // AdMobの初期化
                 GADMobileAds.sharedInstance().start(completionHandler: nil)
             })
-        }
-        // 通知許可の取得
-        UNUserNotificationCenter.current().requestAuthorization(
-            options: [.alert, .sound, .badge]) { (granted, _) in
-                if granted {
-                    UNUserNotificationCenter.current().delegate = self
+
+            // 通知許可の取得
+            UNUserNotificationCenter.current().requestAuthorization(
+                options: [.alert, .sound, .badge]) { (granted, _) in
+                    if granted {
+                        UNUserNotificationCenter.current().delegate = self
+                    }
                 }
-            }
+        }
 
         dataStore = DataStore()
         memoList = dataStore.loadMemo()


### PR DESCRIPTION
## 関連
- close #81 

## 概要
AdMobの表示内容を最適化するためトラッキング許可を取得するダイアログ表示を実装

## スクリーンショット
<img width=150 src="https://user-images.githubusercontent.com/17796784/205446362-8d4e710c-f106-4311-9cdf-998beb447076.png"/>


## 動作確認

- [x] ビルドができること
- [x] トラッキング許可ダイアログが出ること
- [x] 許可すると設定アプリでトラッキングONになっていること

