### PR TITLE
メモ登録後１回目であれば通知を出せるよう修正

### DIFF
--- a/App/LocationNote/LocationNote/Model/Data/Memo.swift
+++ b/App/LocationNote/LocationNote/Model/Data/Memo.swift
@@ -17,4 +17,6 @@ struct Memo: Codable {
     let longitude: Double
     var isSendNotice: Bool
     var lastNoticeDate: Date = Date()
+    // １回目の通知を出しているかどうか(登録後は時間に関わらず出すように)
+    var didsendFirstNotice: Bool = false
 }

--- a/App/LocationNote/LocationNote/Model/Data/Memo.swift
+++ b/App/LocationNote/LocationNote/Model/Data/Memo.swift
@@ -16,7 +16,5 @@ struct Memo: Codable {
     let latitude: Double
     let longitude: Double
     var isSendNotice: Bool
-    var lastNoticeDate: Date = Date()
-    // １回目の通知を出しているかどうか(登録後は時間に関わらず出すように)
-    var didsendFirstNotice: Bool = false
+    var lastNoticeDate: Date?
 }

--- a/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
+++ b/App/LocationNote/LocationNote/Screen/Main/MainViewModel.swift
@@ -100,7 +100,7 @@ final class MainViewModel {
             return
         }
         // 最後に通知を出したのが12時間前であれば通知を出す
-        if Date().compare(Calendar.current.date(byAdding: .hour, value: 12, to: memo.lastNoticeDate)!) == ComparisonResult.orderedDescending {
+        if memo.lastNoticeDate == nil || (Date().compare(Calendar.current.date(byAdding: .hour, value: 12, to: memo.lastNoticeDate!)!) == ComparisonResult.orderedDescending) {
             createUserNotificationRequest(memo: memo)
             // 最終通知表示時間を更新
             memo.lastNoticeDate = Date()

--- a/App/LocationNote/LocationNote/Shared/AppDelegate.swift
+++ b/App/LocationNote/LocationNote/Shared/AppDelegate.swift
@@ -184,7 +184,7 @@ extension AppDelegate {
     private func onDeterminedArea(memo: Memo) {
         var memo = memo
         // 最後に通知を出したのが12時間前であれば通知を出す
-        if (Date().compare(Calendar.current.date(byAdding: .hour, value: 12, to: memo.lastNoticeDate)!) == ComparisonResult.orderedDescending) || !memo.didsendFirstNotice {
+        if memo.lastNoticeDate == nil || (Date().compare(Calendar.current.date(byAdding: .hour, value: 12, to: memo.lastNoticeDate!)!) == ComparisonResult.orderedDescending) {
             createUserNotificationRequest(memo: memo)
             // 最終通知表示時間を更新
             memo.lastNoticeDate = Date()

--- a/App/LocationNote/LocationNote/Shared/AppDelegate.swift
+++ b/App/LocationNote/LocationNote/Shared/AppDelegate.swift
@@ -188,7 +188,6 @@ extension AppDelegate {
             createUserNotificationRequest(memo: memo)
             // 最終通知表示時間を更新
             memo.lastNoticeDate = Date()
-            memo.didsendFirstNotice = true
             dataStore.editMemo(memo: memo)
         }
     }

--- a/App/LocationNote/LocationNote/Shared/AppDelegate.swift
+++ b/App/LocationNote/LocationNote/Shared/AppDelegate.swift
@@ -161,7 +161,7 @@ extension AppDelegate: CLLocationManagerDelegate {
 extension AppDelegate {
     // 近いピンがあるか判定を行う
     private func didUpdateLocations(location: CLLocationCoordinate2D) {
-        guard let memoList =  memoList else {
+        guard let memoList = dataStore.loadMemo() else {
             return
         }
 
@@ -184,10 +184,11 @@ extension AppDelegate {
     private func onDeterminedArea(memo: Memo) {
         var memo = memo
         // 最後に通知を出したのが12時間前であれば通知を出す
-        if Date().compare(Calendar.current.date(byAdding: .hour, value: 12, to: memo.lastNoticeDate)!) == ComparisonResult.orderedDescending {
+        if (Date().compare(Calendar.current.date(byAdding: .hour, value: 12, to: memo.lastNoticeDate)!) == ComparisonResult.orderedDescending) || !memo.didsendFirstNotice {
             createUserNotificationRequest(memo: memo)
             // 最終通知表示時間を更新
             memo.lastNoticeDate = Date()
+            memo.didsendFirstNotice = true
             dataStore.editMemo(memo: memo)
         }
     }

--- a/App/LocationNote/LocationNote/Util/DataStore.swift
+++ b/App/LocationNote/LocationNote/Util/DataStore.swift
@@ -42,6 +42,7 @@ struct DataStore {
         data?[index].detail = memo.detail
         data?[index].isSendNotice = memo.isSendNotice
         data?[index].lastNoticeDate = memo.lastNoticeDate
+        data?[index].didsendFirstNotice = memo.didsendFirstNotice
 
         saveMmemoList(memoList: data ?? [])
     }

--- a/App/LocationNote/LocationNote/Util/DataStore.swift
+++ b/App/LocationNote/LocationNote/Util/DataStore.swift
@@ -42,7 +42,6 @@ struct DataStore {
         data?[index].detail = memo.detail
         data?[index].isSendNotice = memo.isSendNotice
         data?[index].lastNoticeDate = memo.lastNoticeDate
-        data?[index].didsendFirstNotice = memo.didsendFirstNotice
 
         saveMmemoList(memoList: data ?? [])
     }


### PR DESCRIPTION
## 概要
メモ登録後、時間経過しないと通知が受け取れなくなっている。

なので初回は時間に関わらず通知を出せるようにする。


## 動作確認

- [x] ビルドができること
- [x] 時間が立っていなくても通知が出ること

